### PR TITLE
Use more specific node version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 12
+  - 12.13.0
 install:
   - cd app
   - node ./scripts/install_yarn.js


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Fix a travis error with node.js incompatibility by using a more specific version

#### How should this be manually tested?
Tests should pass
