### PR TITLE
Add course info section

### DIFF
--- a/app/site/content/_index.md
+++ b/app/site/content/_index.md
@@ -1,5 +1,14 @@
 ---
 title: "Linear Algebra"
+course_info:
+    instructors:
+      - "Prof. Gilbert Strang"
+    department: "Mathematics"
+    topics:
+      - "Linear Algebra"
+    course_number: "18.06"
+    term: "Spring 2010"
+    level: "Undergraduate"
 menu: 
     main:
         name: "Course Home"

--- a/app/site/layouts/_default/baseof.html
+++ b/app/site/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
         </nav>
         {{ end }}
       </div>
-      <div class="col-md-9">
+      <div class="col-md-10">
         {{ block "main" . }}{{end}}
       </div>
     </div>

--- a/app/site/layouts/index.html
+++ b/app/site/layouts/index.html
@@ -1,13 +1,64 @@
 {{ define "main" }}
 <main aria-role="main">
-    <header class="homepage-header">
-    <h1>{{.Title}}</h1>
-    {{ with .Params.subtitle }}
-    <span class="subtitle">{{.}}</span>
-    {{ end }}
-    </header>
-    <div class="homepage-content">
-    {{.Content}}
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-8">
+                <header class="homepage-header">
+                <h1>{{.Title}}</h1>
+                {{ with .Params.course_info.subtitle }}
+                <span class="subtitle">{{.}}</span>
+                {{ end }}
+                </header>
+                <div class="homepage-content">
+                {{.Content}}
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="container-fluid bg-white">
+                    <h3>Course Info</h3>
+                    <table class="table">
+                        <tr>
+                            <td></td>
+                            <td>Instructor(s)</td>
+                            <td>
+                                <ul>
+                                    {{ range $instructor := .Params.course_info.instructors }}<li>{{ $instructor }}</li>{{ end }}
+                                </ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>Department</td>
+                            <td>{{ .Params.course_info.department }}</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>Topic(s)</td>
+                            <td>
+                                <ul>
+                                    {{ range $topic := .Params.course_info.topics }}<li>{{ $topic }}</li>{{ end }}
+                                </ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>Course No.</td>
+                            <td>{{ .Params.course_info.course_number }}</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>As Taught In</td>
+                            <td>{{ .Params.course_info.term }}</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>Level</td>
+                            <td>{{ .Params.course_info.level }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 </main>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [ ] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/36

#### What's this PR do?
Adds basic course info metadata example to the course home markdown and HTML to display it in the template.

#### How should this be manually tested?
Run the site, you should see course info as displayed in the screenshots.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/69462609-72ea0580-0d47-11ea-960e-a868be2098a7.png)

![image](https://user-images.githubusercontent.com/12089658/69462751-d6743300-0d47-11ea-8940-bce116bb9bc1.png)