### PR TITLE
fix path to 'dist'

### DIFF
--- a/src/webpack/webpack.common.js
+++ b/src/webpack/webpack.common.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   output: {
-    path: path.join(__dirname, "dist")
+    path: path.join(__dirname, "../../dist")
   },
 
   module: {


### PR DESCRIPTION
had a small issue with the build path for webpack assets. this fixes it, so the built CSS ends up in the `dist` dir instead of `src/webpack/dist` (lol)