### PR TITLE
Mobile nav menu items fix

### DIFF
--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -14,6 +14,7 @@
   <body>
     <div class="overflow-auto {{ if .IsHome }}course-home-background{{else}}course-background{{ end }}">
       <div class="bmd-layout-container bmd-drawer-f-l bmd-drawer-overlay outer-wrapper">
+        {{ partial "mobile_nav.html" . }}
         {{ block "header" . }}{{ partial "header" . }}{{end}}
         <div class="container-fluid">
           <div class="row outer-wrapper">

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -1,4 +1,3 @@
-{{ partial "mobile_nav.html" . }}
 <div id="desktop-header">
   <div class="contents p-4 pl-8">
     <div class="ocw-logo-placeholder mr-6">

--- a/site/layouts/partials/mobile_nav.html
+++ b/site/layouts/partials/mobile_nav.html
@@ -1,5 +1,5 @@
 <div id="course-nav" class="bmd-layout-drawer bg-faded bg-light medium-and-below-only">
-    {{ with .Site.Menus.main }}
+    {{ with (index .Site.Menus .CurrentSection.Params.course_id) }}
     <nav>
         <ul>
             {{ range . }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/66

#### What's this PR do?
Moves mobile nav outside header partial and updates it to use the new menu structure.

#### How should this be manually tested?
Spin up the test site with `docker-compose up --build` and reduce window size to mobile width.  Clicking "Browse Course Material" should show the mobile nav with menu items populated.