### PR TITLE
mobile drawers (course nav and course info)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "bootstrap-material-design": "^4.1.2",
     "jquery": "^3.4.1",
     "material-icons": "^0.3.1",
+    "offcanvas-bootstrap": "^2.5.2",
     "popper.js": "^1.16.0",
     "react-bootstrap": "^1.0.0-beta.15",
     "react-hot-loader": "^4.12.17",

--- a/site/layouts/courseindex/baseof.html
+++ b/site/layouts/courseindex/baseof.html
@@ -13,10 +13,8 @@
   </head>
   <body>
     <div class="overflow-auto {{ if .IsHome }}course-home-background{{else}}course-background{{ end }}">
-      <div class="bmd-layout-container bmd-drawer-f-l bmd-drawer-overlay outer-wrapper">
-        <div class="container-fluid">
-          {{ block "main" . }}{{end}}
-        </div>
+      <div class="container-fluid">
+        {{ block "main" . }}{{end}}
       </div>
     </div>
     {{ block "footer" . }}{{ partial "footer" . }}{{end}}

--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -13,26 +13,35 @@
   </head>
   <body>
     <div class="overflow-auto {{ if .IsHome }}course-home-background{{else}}course-background{{ end }}">
-      <div class="bmd-layout-container bmd-drawer-f-l bmd-drawer-overlay outer-wrapper">
-        {{ partial "mobile_nav.html" . }}
-        {{ block "header" . }}{{ partial "header" . }}{{end}}
-        <div class="container-fluid">
-          <div class="row outer-wrapper">
-            {{ partial "desktop_nav.html" . }}
-            <div id="main-content-wrapper" class="col-lg-9 p-0">
-              <main aria-role="main">
-                <div class="container-fluid p-0">
-                  <div class="row m-0">
-                    <div class="col-12 col-lg-8 col-xl-8 px-3 px-md-6 mt-3 mt-lg-6">
-                      {{ block "main" . }}{{end}}
-                    </div>
-                    <div class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">
-                      {{ partial "course_info.html" .CurrentSection }}
-                    </div>
+      {{ partial "mobile_nav.html" . }}
+      {{ partial "mobile_course_info.html" . }}
+      {{ block "header" . }}{{ partial "header" . }}{{end}}
+      <div class="mobile-course-info-toggle medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
+        <div
+          id="toggle"
+          class="btn px-2 m-0 navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
+          data-toggle="offcanvas"
+          data-target="#course-info-drawer"
+          >
+          Course Info
+        </div>
+      </div>
+      <div class="container-fluid">
+        <div class="row outer-wrapper">
+          {{ partial "desktop_nav.html" . }}
+          <div id="main-content-wrapper" class="col-lg-9 p-0">
+            <main aria-role="main">
+              <div class="container-fluid p-0">
+                <div class="row m-0">
+                  <div class="col-12 col-lg-8 col-xl-8 px-3 px-md-6 mt-3 mt-lg-6">
+                    {{ block "main" . }}{{end}}
+                  </div>
+                  <div class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">
+                    {{ partial "course_info.html" .CurrentSection }}
                   </div>
                 </div>
-              </main>
-            </div>
+              </div>
+            </main>
           </div>
         </div>
       </div>
@@ -41,6 +50,5 @@
       {{ with $script.js }}
       <script src="{{ relURL . }}"></script>
       {{ end }}
-    </div>
   </body>
 </html>

--- a/site/layouts/partials/mobile_course_info.html
+++ b/site/layouts/partials/mobile_course_info.html
@@ -1,3 +1,6 @@
-<div id="course-info-drawer" dir="rtl" class="bmd-layout-drawer bg-faded bg-light medium-and-below-only">
+<div
+  id="course-info-drawer"
+  class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only nav-drawer"
+>
   {{ partial "course_info.html" .CurrentSection }}
 </div>

--- a/site/layouts/partials/mobile_nav.html
+++ b/site/layouts/partials/mobile_nav.html
@@ -1,4 +1,6 @@
-<div id="course-nav" class="bmd-layout-drawer bg-faded bg-light medium-and-below-only">
+<div
+  id="course-nav"
+  class="navbar-offcanvas medium-and-below-only nav-drawer">
   <h5 class="text-uppercase mb-2 mt-5 ml-2">Browse Course Materials</h5>
   {{ partial "nav.html" . }}
 </div>

--- a/site/layouts/partials/mobile_nav_toggle.html
+++ b/site/layouts/partials/mobile_nav_toggle.html
@@ -1,7 +1,8 @@
 <div class="mobile-course-nav-toggle medium-and-below-only">
   <div
-    class="btn bg-dark-gray pl-5 d-inline-flex align-items-center rounded-0"
-    data-toggle="drawer"
+    id="mobile-course-nav-toggle"
+    class="btn bg-dark-gray pl-5 d-inline-flex align-items-center rounded-0 navbar-toggle offcanvas-toggle"
+    data-toggle="offcanvas"
     data-target="#course-nav"
   >
     <span class="text-uppercase font-weight-bold pr-2">browse course material</span>

--- a/src/css/bootstrap-overrides.scss
+++ b/src/css/bootstrap-overrides.scss
@@ -14,3 +14,5 @@ $spacers: map-merge(
   ),
   $spacers
 );
+
+$screen-xs-max: 991px;

--- a/src/css/course-nav.scss
+++ b/src/css/course-nav.scss
@@ -17,3 +17,13 @@
     font-size: 20px;
   }
 }
+
+.mobile-course-info-toggle {
+  position: absolute;
+  right: 0;
+  z-index: 10;
+
+  #toggle {
+    writing-mode: vertical-lr;
+  }
+}

--- a/src/css/drawer.scss
+++ b/src/css/drawer.scss
@@ -1,0 +1,3 @@
+.nav-drawer {
+  background: white;
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -2,6 +2,7 @@
 @import "bootstrap-overrides";
 @import "variables";
 @import "~bootstrap/scss/bootstrap";
+@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 $material-icons-font-path: "~material-icons/iconfont/";
 
@@ -10,6 +11,7 @@ $material-icons-font-path: "~material-icons/iconfont/";
 @import "header";
 @import "course-nav";
 @import "course-info";
+@import "drawer";
 
 /* CUSTOM STYLES */
 
@@ -106,11 +108,6 @@ table {
   @include media-breakpoint-down(md) {
     color: $white !important;
   }
-}
-
-.bmd-drawer-f-l > .bmd-layout-drawer {
-  width: $drawer-width !important;
-  transform: translateX(-100vw);
 }
 
 .container-fluid {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import $ from "jquery"
 import Popper from "popper.js"
 import "bootstrap-material-design"
 import tippy from "tippy.js"
+import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
 
 window.jQuery = $
 window.$ = $
@@ -12,13 +13,13 @@ window.Popper = Popper
 
 $(document).ready(() => {
   $("body").bootstrapMaterialDesign()
-})
 
-// hacky coming-soon popover
-document.querySelectorAll(".coming-soon").forEach(el => {
-  tippy(el, {
-    content:   "Coming soon!",
-    trigger:   "click",
-    placement: "top"
+  // hacky coming-soon popover
+  document.querySelectorAll(".coming-soon").forEach(el => {
+    tippy(el, {
+      content:   "Coming soon!",
+      trigger:   "click",
+      placement: "top"
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6612,6 +6612,11 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
+offcanvas-bootstrap@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/offcanvas-bootstrap/-/offcanvas-bootstrap-2.5.2.tgz#34c7f159d82e28a3c872d1a69b1601f5f34c99ed"
+  integrity sha512-LlwdfGG6p0Sd35hBmQftxm9R6IHPQddPSbKwPWrGwd2o+phD7SLyXZbhWk9VNiz26uy7J9WiQKLVGWTZGFkgUA==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

https://trello.com/c/vjF0VNOk/26-mobile-course-navigation-drawer
https://trello.com/c/3ajMJlbT/25-mobile-course-info-drawer

#### What's this PR do?

this adds a second drawer, on the right-hand side, to hold the course info panel on mobile. It also adds a button for opening that drawer.

In order to get this to work I had to swap out our existing drawer component (which was from the bootstrap material design package). I tried out a few options before settling on this one: https://github.com/iamphill/Bootstrap-Offcanvas

#### How should this be manually tested?

try out navigating the course at various widths, especially tablet and phone widths. things should look alright and work well.



#### Screenshots (if appropriate)

![Screenshot from 2020-02-14 14-30-33](https://user-images.githubusercontent.com/6207644/74561454-954e8200-4f36-11ea-941f-943cb5990b44.png)
![Screenshot from 2020-02-14 14-29-08](https://user-images.githubusercontent.com/6207644/74561455-95e71880-4f36-11ea-94d9-1776cccfde8f.png)
![Screenshot from 2020-02-14 14-28-58](https://user-images.githubusercontent.com/6207644/74561456-95e71880-4f36-11ea-8198-7026b158767c.png)

