### PR TITLE
turn off webpack watching the `/dist` folder, since it gets too heavy

### DIFF
--- a/src/webpack/webpack.common.js
+++ b/src/webpack/webpack.common.js
@@ -51,7 +51,8 @@ module.exports = {
           {
             loader:  MiniCssExtractPlugin.loader,
             options: {
-              publicPath: "./"
+              publicPath: "./",
+              hmr:        process.env.NODE_ENV !== "production"
             }
           },
           "css-loader",

--- a/src/webpack/webpack.dev.js
+++ b/src/webpack/webpack.dev.js
@@ -10,13 +10,14 @@ module.exports = merge(common, {
 
   output: {
     filename:      "[name].js",
-    chunkFilename: "[id].css"
+    chunkFilename: "[id].css",
+    publicPath:    "/"
   },
 
   devServer: {
     port:               process.env.PORT || 3000,
     contentBase:        path.join(process.cwd(), "./dist"),
-    watchContentBase:   true,
+    hot:                true,
     quiet:              false,
     open:               true,
     historyApiFallback: {


### PR DESCRIPTION
config tweak

turn of the 'watchContentBase' option in the development webpack config. basically, having this option on meant that every time the hugo site rebuilt, because a template is saved or whatever, every single file being written in the `/dist` dir gets picked up by weback. on my computer this causes the tab that the site is open in to lock up completely.

turning off the content watch mode fixes this. the downside is that after saving a template change the browser will not automatically refresh, but that's alright.