### PR TITLE
switch from using webpack as main server to using hugo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: hugo-course-publisher
     ports:
       - "3000:3000"
+      - "3001:3001"
     volumes:
       - .:/usr/share/
     command: bash -c "yarn install && npm start"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint src",
     "start": "run-p start:**",
-    "start:hugo": "hugo -d ../dist -s site -vw",
+    "start:hugo": "hugo server -s site -p 3000 --bind 0.0.0.0",
     "start:webpack": "webpack-dev-server --config src/webpack/webpack.dev.js --hot --host 0.0.0.0",
     "preview": "run-p preview:**",
     "preview:hugo": "npm run start:hugo -- -D -F",

--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -8,8 +8,10 @@
       href="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}">
     <title>{{ $.Site.Title }}</title>
     {{ $stylesheet := .Site.Data.webpack.main }}
-    {{ with $stylesheet.css }}
-    <link href="{{ relURL . }}" rel="stylesheet">
+    {{ if .Site.IsServer }}
+      <link href="{{ print "http://localhost:3001" $stylesheet.css  }}" rel="stylesheet">
+    {{ else }}
+      <link href="{{ relURL $stylesheet.css }}" rel="stylesheet">
     {{ end }}
   </head>
   <body>
@@ -50,8 +52,10 @@
       </div>
       {{ block "footer" . }}{{ partial "footer" . }}{{end}}
       {{ $script := .Site.Data.webpack.main }}
-      {{ with $script.js }}
-      <script src="{{ relURL . }}"></script>
+      {{ if .Site.IsServer }}
+        <script src="{{ print "http://localhost:3001" $script.js }}"></script>
+      {{ else }}
+        <script src="{{ relURL $script.js }}"></script>
       {{ end }}
   </body>
 </html>

--- a/src/webpack/webpack.dev.js
+++ b/src/webpack/webpack.dev.js
@@ -15,11 +15,16 @@ module.exports = merge(common, {
   },
 
   devServer: {
-    port:               process.env.PORT || 3000,
-    contentBase:        path.join(process.cwd(), "./dist"),
-    hot:                true,
-    quiet:              false,
-    open:               true,
+    port:    process.env.PORT || 3001,
+    hot:     true,
+    quiet:   false,
+    open:    false,
+    headers: {
+      "Access-Control-Allow-Origin":  "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "X-Requested-With, content-type, Authorization"
+    },
     historyApiFallback: {
       rewrites: [{ from: /./, to: "404.html" }]
     }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

tooling change, this sets us up to use the hugo server instead of using webpack to serve html.

this is nice, because `hugo server` has a built-in live-reloading thing which is very fast. it seems to work just fine alongside the webpack hot-reloading as well.

to get this to work I basically just:

- changed hugo to use the `server` option instead
- changed webpack's port to `3001`
- made a small change to our `baseof` template that looks at the `.Site.IsServer` variable to figure out whether to make a request for the CSS and JS assets from the webpack dev server or from the compiled asset.

#### How should this be manually tested?

dev env should work normally