### PR TITLE
fix table overflow

### DIFF
--- a/site/layouts/courseindex/baseof.html
+++ b/site/layouts/courseindex/baseof.html
@@ -12,7 +12,7 @@
     {{ end }}
   </head>
   <body>
-    <div class="overflow-auto {{ if .IsHome }}course-home-background{{else}}course-background{{ end }}">
+    <div class="overflow-auto">
       <div class="container-fluid">
         {{ block "main" . }}{{end}}
       </div>

--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -13,7 +13,7 @@
     {{ end }}
   </head>
   <body>
-    <div class="overflow-auto {{ if .IsHome }}course-home-background{{else}}course-background{{ end }}">
+    <div class="overflow-auto">
       {{ partial "mobile_nav.html" . }}
       {{ partial "mobile_course_info.html" . }}
       {{ block "header" . }}{{ partial "header" . }}{{end}}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -178,7 +178,9 @@ table {
 
 article.content {
   // sometimes the tables can be wide, and on mobile that can ruin the overall page width
-  // mais, malheureusement, bootstrap n'a pas un class définé pour indiquer qu'il faut avoir
-  // overflow: scroll!
-  overflow: scroll;
+  // this forces the table to scroll if it's too wide
+  table {
+    display: block;
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #90 

#### What's this PR do?

this basically fixes up how we style tables in the markdown content so that they don't blow up the scrolling on the page

#### How should this be manually tested?

try a course like <localhost:3000/courses/20-219-becoming-the-next-bill-nye-writing-and-hosting-the-educational-show-january-iap-2015/sections/day-1-identity-and-genre/>

make sure that the table itself scrolls horizontally on mobile, but that it doesn't take all the page content with it.

#### Screenshots (if appropriate)

![Screenshot from 2020-03-03 14-44-05](https://user-images.githubusercontent.com/6207644/75813108-6cfbbb80-5d5d-11ea-83ae-35a9924ecbcf.png)
![Screenshot from 2020-03-03 14-43-58](https://user-images.githubusercontent.com/6207644/75813111-6d945200-5d5d-11ea-9299-df60ded76f20.png)

