### PR TITLE
Max width

### DIFF
--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -32,7 +32,8 @@
       <div class="container-fluid">
         <div class="row outer-wrapper">
           {{ partial "desktop_nav.html" . }}
-          <div id="main-content-wrapper" class="col-lg-9 p-0">
+          <div class="left-col-bg"></div>
+          <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
             <main aria-role="main">
               <div class="container-fluid p-0">
                 <div class="row m-0">

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -1,5 +1,6 @@
 #desktop-header {
   background-color: $bg-gray;
+  border-bottom: 1px solid $border-dark-color;
 
   @include media-breakpoint-down(md) {
     display: none;
@@ -7,8 +8,9 @@
 
   .contents {
     display: flex;
+    margin: 0 auto;
+    max-width: $max-content-width;
     align-items: center;
-    border-bottom: 1px solid $border-dark-color;
 
     .bmd-form-group {
       padding-top: 0;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -33,8 +33,19 @@ a {
 }
 
 .outer-wrapper {
+  max-width: $max-content-width;
   min-height: 100vh;
   margin: auto auto;
+}
+
+.left-col-bg {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  width: 50vw;
+  height: 100vh;
+  background-color: $light-gray;
+  z-index: -1;
 }
 
 .medium-and-below-only {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -47,13 +47,19 @@ a {
 }
 
 .left-col-bg {
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  width: 50vw;
-  height: 100vh;
-  background-color: $light-gray;
-  z-index: -1;
+  @include media-breakpoint-up(lg) {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 50vw;
+    height: 100vh;
+    background-color: $light-gray;
+    z-index: -1;
+  }
+  
+  @include media-breakpoint-down(md) {
+    display: none;
+  }
 }
 
 .medium-and-below-only {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -39,7 +39,7 @@ a {
   @include media-breakpoint-up(lg) {
     max-width: $max-content-width;
   }
-  
+
   @include media-breakpoint-down(md) {
     max-width: 100vw;
     overflow-x: hidden;
@@ -56,7 +56,7 @@ a {
     background-color: $light-gray;
     z-index: -1;
   }
-  
+
   @include media-breakpoint-down(md) {
     display: none;
   }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -33,9 +33,17 @@ a {
 }
 
 .outer-wrapper {
-  max-width: $max-content-width;
   min-height: 100vh;
   margin: auto auto;
+
+  @include media-breakpoint-up(lg) {
+    max-width: $max-content-width;
+  }
+  
+  @include media-breakpoint-down(md) {
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
 }
 
 .left-col-bg {

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -1,3 +1,4 @@
+$max-content-width: 1447px;
 $enable-responsive-font-sizes: true;
 $font-size-base: 0.8rem;
 $headings-font-weight: 600;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/vJiN2AaE/48-add-max-width-to-desktop

#### What's this PR do?
Adds a max width to the desktop layout based on the GitBook docs page, setting it on the `.outer-wrapper` class.  A fixed position div was added to the left side with a width of 50% and height of 100%.  The same `$light-grey` background as the left nav was set on this div, and a white background was set on the content div to the right of it.  The mid-point on the fixed position div will never be exposed.  The max width can be changed simply by altering the `$max-content-width` variable in `variables.scss`.

#### How should this be manually tested?
Run the site, verify that you can expand the window large (or zoom out if you have a small monitor) and that the content doesn't expand beyond the max width.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/75816015-615ec380-5d62-11ea-934f-ebd98fb7837a.png)
