### PR TITLE
add stylesheet switcher

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,5 +8,9 @@
   },
   "rules": {
       "no-unused-vars": 0
+  },
+  "env": {
+      "browser": true,
+      "jquery": true
   }
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -12,6 +12,7 @@ $material-icons-font-path: "~material-icons/iconfont/";
 @import "course-nav";
 @import "course-info";
 @import "drawer";
+@import "theme-one";
 
 /* CUSTOM STYLES */
 

--- a/src/css/theme-one.scss
+++ b/src/css/theme-one.scss
@@ -1,0 +1,10 @@
+html.theme-one {
+  * {
+    background: pink;
+    color: teal;
+  }
+
+  :not(i) {
+    text-transform: uppercase;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Popper from "popper.js"
 import "bootstrap-material-design"
 import tippy from "tippy.js"
 import "offcanvas-bootstrap/dist/js/bootstrap.offcanvas.js"
+import { initTheme } from "./js/stylesheets"
 
 window.jQuery = $
 window.$ = $
@@ -22,4 +23,6 @@ $(document).ready(() => {
       placement: "top"
     })
   })
+
+  initTheme()
 })

--- a/src/js/stylesheets.js
+++ b/src/js/stylesheets.js
@@ -1,0 +1,52 @@
+const BASE_THEME = "BASE_THEME"
+const THEME_VARIANT_ONE = "THEME_VARIANT_ONE"
+
+const THEME_CLASSNAMES = {
+  [BASE_THEME]:        "",
+  [THEME_VARIANT_ONE]: "theme-one"
+}
+
+const THEME_OPTIONS = [
+  { value: BASE_THEME, label: "Base Theme" },
+  { value: THEME_VARIANT_ONE, label: "Theme #1" }
+]
+
+const STORAGE_KEY = "ocw-theme"
+
+const getTheme = () => window.localStorage.getItem(STORAGE_KEY) || BASE_THEME
+
+const setTheme = theme => window.localStorage.setItem(STORAGE_KEY, theme)
+
+const setThemeClass = theme => {
+  $("html").removeClass()
+  $("html").addClass(THEME_CLASSNAMES[theme])
+}
+
+const selectCSS = {
+  position: "absolute",
+  top:      2,
+  right:    5
+}
+
+export const initTheme = () => {
+  const currentTheme = getTheme()
+  setThemeClass(currentTheme)
+
+  const selectEl = $(`<select>`).appendTo("body")
+  selectEl.attr("value", currentTheme)
+  selectEl.css(selectCSS)
+
+  THEME_OPTIONS.forEach(({ value, label }) => {
+    const option = $(`<option value=${value}>${label}</option>`)
+    if (value === currentTheme) {
+      option.attr("selected", true)
+    }
+    selectEl.append(option)
+  })
+
+  selectEl.change(e => {
+    const { value } = e.target
+    setTheme(value)
+    setThemeClass(value)
+  })
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review


#### What are the relevant tickets?

no gh ticket

#### What's this PR do?

this basically adds a 'theme' engine of sorts that allows the user to dynamically switch between a few different stylesheets. it adds a little drop-down in the upper right hand corner of the page. selecting an option in the dropdown sets a class on the `html` element, which can then by used to style the page differently.

Just for testing purposes I included a lovely theme that makes things pink and uppercase.

#### How should this be manually tested?

You should be able to switch between the two themes. changes should take effect immediately. your selection should persist across refreshes.

note that there is a brief flash before the JS is executed when you have the pink theme selected - imo this is not something to worry about.

#### Screenshots (if appropriate)

![Screenshot from 2020-03-04 16-51-19](https://user-images.githubusercontent.com/6207644/75926340-60986100-5e38-11ea-9732-cb742769110a.png)

