### PR TITLE
fix course image display on desktop

### DIFF
--- a/site/layouts/courses/section.html
+++ b/site/layouts/courses/section.html
@@ -1,25 +1,23 @@
 {{ define "main" }}
 {{ $course_home := printf "%s/%s/%s" "courses" .CurrentSection.Params.course_id "_index.md" }}
 {{ if eq .File.Path $course_home }}
-<div class="homepage-content">
-  <div class="large-and-above-only">
-    {{ partial "course_image.html" . }}
-  </div>
-  <div class="container-fluid pt-0 pt-md-4 pb-4">
-    <div class="row medium-and-below-only px-3 pb-2 justify-content-between">
+<div class="homepage-content d-flex">
+  <div class="container-fluid pt-0 pb-4">
+    <div class="row px-3 pb-2 justify-content-between">
       <div class="col pl-0 pr-1">
         <h2 class="text-uppercase">{{ .Params.course_title }}</h2>
         {{ partial "course_instructor_number.html" . }}
       </div>
-      <img class="w-25 mobile-course-image img-thumbnail" src="{{ absURL .CurrentSection.Params.course_image_url }}" />
+      <img class="w-25 course-image medium-and-below-only img-thumbnail" src="{{ absURL .CurrentSection.Params.course_image_url }}" />
     </div>
     {{ partial "mobile_nav_toggle.html" . }}
     <h5 class="font-weight-bold pt-2">Course Description</h5>
-    <div class="border-bottom-light mb-3">{{ .Params.course_description | safeHTML }}</div>
+    <div class="mb-3">{{ .Params.course_description | safeHTML }}</div>
     <div class="medium-and-below-only">
       {{ partial "course_info.html" .CurrentSection }}
     </div>
   </div>
+  <img class="w-25 course-image img-thumbnail large-and-above-only h-100" src="{{ absURL .CurrentSection.Params.course_image_url }}" />
 </div>
 {{ else }}
 {{ partial "course_section.html" . }}

--- a/site/layouts/partials/course_image.html
+++ b/site/layouts/partials/course_image.html
@@ -1,5 +1,0 @@
-<div class="pt-6 pb-0 mb-0 jumbotron jumbotron-fluid course-image" style="background-image: url({{ .CurrentSection.Params.course_image_url }})">
-    <div class="container mt-4 p-3">
-        <h1 class="text-uppercase text-white">{{ .Params.course_title }}</h1>
-    </div>
-</div>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -3,15 +3,11 @@
     <tr>
       <td class="pl-0 py-0 p-md-2">Instructor(s)</td>
       <td class="pl-0 py-0 p-md-2">
-        <ul class="list-unstyled m-0">
-          {{ range $instructor := .Params.course_info.instructors }}
-          <li>
-            <a href="#" class="coming-soon">
-              {{ $instructor }}
-            </a>
-          </li>
-          {{ end }}
-        </ul>
+        {{ range $instructor := .Params.course_info.instructors }}
+        <a href="#" class="coming-soon pr-1">
+          {{ $instructor }}
+        </a>
+        {{ end }}
       </td>
     </tr>
     <tr>

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -82,12 +82,11 @@ a {
 }
 
 .course-image {
-  background-size: cover;
-}
+  @include media-breakpoint-down(md) {
+    height: 100px;
+    width: 150px;
+  }
 
-.mobile-course-image {
-  height: 100px;
-  width: 150px;
   object-fit: cover;
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

in trello

#### What's this PR do?

this fixes the rendering of the course image, title, etc on the course home page to be in line with the mocks.

#### How should this be manually tested?

check out the course home page and make sure it looks good! the mobile page should be unchanged.

#### Screenshots (if appropriate)

![Screenshot from 2020-03-05 09-58-44](https://user-images.githubusercontent.com/6207644/75993900-2d051780-5ec8-11ea-8e84-3098e4da37d6.png)
