### PR TITLE
make sidebar look more gitbook-ey

### DIFF
--- a/site/layouts/courses/baseof.html
+++ b/site/layouts/courses/baseof.html
@@ -38,7 +38,7 @@
             <main aria-role="main">
               <div class="container-fluid p-0">
                 <div class="row m-0">
-                  <div class="col-12 col-lg-8 col-xl-8 px-3 px-md-6 mt-3 mt-lg-6">
+                  <div class="col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6">
                     {{ block "main" . }}{{end}}
                   </div>
                   <div class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">

--- a/site/layouts/courses/section.html
+++ b/site/layouts/courses/section.html
@@ -12,7 +12,7 @@
     </div>
     {{ partial "mobile_nav_toggle.html" . }}
     <h5 class="font-weight-bold pt-2">Course Description</h5>
-    <div class="mb-3">{{ .Params.course_description | safeHTML }}</div>
+    <div class="mb-3 course-description">{{ .Params.course_description | safeHTML }}</div>
     <div class="medium-and-below-only">
       {{ partial "course_info.html" .CurrentSection }}
     </div>

--- a/site/layouts/partials/topic.html
+++ b/site/layouts/partials/topic.html
@@ -18,7 +18,7 @@
   </span>
 </div>
 {{ if gt (len .subtopics) 0 }}
-<div class="pl-4 collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $index }}">
+<div class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $index }}">
   {{- $context.Scratch.Set "subtopicIndex" 0 -}}
   {{ range $subtopic, $specialities := .subtopics }}
   {{- $subtopicIndex := $context.Scratch.Get "subtopicIndex" -}}

--- a/src/css/gitbook.scss
+++ b/src/css/gitbook.scss
@@ -1,5 +1,7 @@
 $gitbook-blue-grey: #f5f7f9;
 $gitbook-border-grey: #d4dadf;
+$gitbook-grey: #74818d;
+$gitbook-grey-light: #9daab6;
 $gitbook-border-light: #e6ecf1;
 $gitbook-blue: rgb(56, 132, 254);
 
@@ -8,13 +10,28 @@ html.gitbook {
     font-family: "Roboto" !important;
   }
 
+  .homepage-content {
+    h2 {
+      margin-top: 0;
+      margin-bottom: 10px;
+    }
+
+    .course-description {
+      margin-right: 15px;
+    }
+  }
+
+  .left-col-bg {
+    background-color: $gitbook-blue-grey !important;
+  }
+
   p {
     font-size: 16px;
     margin-bottom: 24px;
   }
 
   h2 {
-    margin: 24px 0;
+    margin: 32px 0;
   }
 
   main {
@@ -58,6 +75,41 @@ html.gitbook {
         text-transform: none !important;
         font-weight: 500;
         font-size: 14px;
+        display: block;
+      }
+    }
+  }
+
+  .course-info {
+    font-size: 12px;
+    color: $gitbook-grey !important;
+    font-weight: 500;
+
+    .border-bottom-light {
+      border-bottom: none !important;
+    }
+
+    h5.font-weight-bold {
+      text-transform: uppercase;
+      font-size: 10px;
+      color: $gitbook-grey-light;
+    }
+
+    table.table {
+      color: $gitbook-grey !important;
+    }
+
+    a {
+      color: $gitbook-grey !important;
+    }
+
+    .font-weight-bold {
+      font-weight: 500 !important;
+    }
+
+    .subtopic-container {
+      a.font-weight-bold {
+        font-weight: 400 !important;
       }
     }
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

this gets the sidebar styling more gitbook-ey-looking

#### How should this be manually tested?

just try it out and make sure it looks alright to you


#### Screenshots (if appropriate)

![Screenshot from 2020-03-16 12-17-13](https://user-images.githubusercontent.com/6207644/76782612-eeecdb00-6786-11ea-8d9f-843523415899.png)

![Screenshot from 2020-03-16 12-14-56](https://user-images.githubusercontent.com/6207644/76782614-ef857180-6786-11ea-972c-3782e6888cbd.png)

for comparison, this is the sidebar on gitbooks:

![Screenshot from 2020-03-16 12-15-01](https://user-images.githubusercontent.com/6207644/76782613-ef857180-6786-11ea-834a-b3149e9b6c68.png)