### PR TITLE
make PDF viewer have a fixed aspect ratio at all widths

### DIFF
--- a/site/layouts/partials/pdf_viewer.html
+++ b/site/layouts/partials/pdf_viewer.html
@@ -1,12 +1,12 @@
-<div class="w-100 h-100">
+<div class="pdf-viewer w-100 pb-5">
   <div class="pr-4">
-    <a href="{{ .Params.file_location }}">
+    <a class="download-link" href="{{ .Params.file_location }}">
       <div class="btn bg-dark-gray rounded float-right mb-3">
         <span>DOWNLOAD</span>
         <div class="ripple-container"></div>
       </div>
     </a>
   </div>
-  <div class="pdf-wrapper w-100 h-100" data-pdfurl="{{ .Params.file_location }}">
+  <div class="pdf-wrapper w-100" data-pdfurl="{{ .Params.file_location }}">
   </div>
 </div>

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -13,6 +13,7 @@ $material-icons-font-path: "~material-icons/iconfont/";
 @import "course-info";
 @import "drawer";
 @import "gitbook";
+@import "pdf";
 
 /* CUSTOM STYLES */
 

--- a/src/css/pdf.scss
+++ b/src/css/pdf.scss
@@ -1,0 +1,20 @@
+.pdf-viewer {
+  .download-link {
+    display: block;
+    height: 50px;
+  }
+
+  .pdf-wrapper {
+    height: 0;
+    padding-bottom: 130%;
+    position: relative;
+
+    iframe {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, just a styling tweak on the PDF viewer

#### What's this PR do?

this restyles the wrapper div and the PDF viewer so that it has a fixed aspect ratio (see screens below) which will ensure that when you open a PDF page by default you see the first whole page of the PDF. And also that you can scroll to view a whole page at a time, instead of the aspect ratio getting a little wonky.

#### How should this be manually tested?

try it out and make sure it works alright! should be good on mobile too.


#### Screenshots (if appropriate)

![Screenshot from 2020-03-26 14-44-59](https://user-images.githubusercontent.com/6207644/77684426-5cabba80-6f70-11ea-8953-8b74a1268f29.png)
![Screenshot from 2020-03-26 14-44-44](https://user-images.githubusercontent.com/6207644/77684427-5cabba80-6f70-11ea-8135-1a07b63775ee.png)
![Screenshot from 2020-03-26 14-44-38](https://user-images.githubusercontent.com/6207644/77684428-5d445100-6f70-11ea-9b72-c906dc85638c.png)