### PR TITLE
Fix instructor / course no. title spacing

### DIFF
--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -1,8 +1,8 @@
 <div class="instructor-and-number">
   <table class="table table-borderless mb-2">
     <tr>
-      <td class="pl-0 py-0 p-md-2">Instructor(s)</td>
-      <td class="pl-0 py-0 p-md-2">
+      <td class="px-0 py-2">Instructor(s)</td>
+      <td class="px-0 py-2">
         {{ range $instructor := .Params.course_info.instructors }}
         <a href="#" class="coming-soon pr-1">
           {{ $instructor }}
@@ -11,8 +11,8 @@
       </td>
     </tr>
     <tr>
-      <td class="pl-0 py-0 p-md-2">Course No.</td>
-      <td class="pl-0 py-0 p-md-2">{{ .Params.course_info.course_number }}</td>
+      <td class="px-0 py-2">Course No.</td>
+      <td class="px-0 py-2">{{ .Params.course_info.course_number }}</td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://trello.com/c/sCn5mXiU/78-align-instructor-and-course-number-tags-with-the-header

#### What's this PR do?
The `p-md-2` class was removed from table cells that were using it in `course_instructor_number.html` and `px-0 py-2` was used in its place.  Individual spacing rules like `px-0` do not automatically take precedence if you are including a class like p-md-2 because all of these spacing rules use `!important` under the hood.

#### How should this be manually tested?
Run the site or visit the deploy preview, verify that the alignment is correct.

#### Screenshots (if appropriate)
![Screen Shot 2020-04-01 at 4 43 16 PM](https://user-images.githubusercontent.com/12089658/78184758-fe7f4b80-7437-11ea-8ec4-ad073dc205af.png)
![Screen Shot 2020-04-01 at 4 45 04 PM](https://user-images.githubusercontent.com/12089658/78184889-3b4b4280-7438-11ea-8413-cae9b659f3bb.png)