### PR TITLE
Fix course number display outside of course info partial

### DIFF
--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -12,7 +12,13 @@
     </tr>
     <tr>
       <td class="px-0 py-2">Course No.</td>
-      <td class="px-0 py-2">{{ .Params.course_info.course_number }}</td>
+      <td class="px-0 py-2">
+        {{ range $course_number := .Params.course_info.course_numbers }}
+        <a href="#" class="coming-soon pr-1">
+          {{ $course_number }}
+        </a>
+        {{ end }}
+      </td>
     </tr>
   </table>
 </div>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -13,7 +13,8 @@
     <tr>
       <td class="px-0 py-2">Course No.</td>
       <td class="px-0 py-2">
-        {{ range $course_number := .Params.course_info.course_numbers }}
+        {{ range $index, $course_number := .Params.course_info.course_numbers }}
+        {{ if $index }}, {{ end }}
         <a href="#" class="coming-soon pr-1">
           {{ $course_number }}
         </a>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -13,12 +13,12 @@
     <tr>
       <td class="px-0 py-2">Course No.</td>
       <td class="px-0 py-2">
-        {{ range $index, $course_number := .Params.course_info.course_numbers }}
-        {{ if $index }}, {{ end }}
-        <a href="#" class="coming-soon pr-1">
-          {{ $course_number }}
+        {{- range $index, $course_number := .Params.course_info.course_numbers -}}
+        {{- if $index -}},&nbsp;{{- end -}}
+        <a href="#" class="coming-soon">
+          {{- $course_number -}}
         </a>
-        {{ end }}
+        {{- end -}}
       </td>
     </tr>
   </table>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/117

#### What's this PR do?
Fixes the course number display on course pages so they show up as a comma separated list of clickable links.

#### How should this be manually tested?
Run the site or visit the deploy preview.  View different course pages and verify that the course number links appear as expected, and that they say coming soon when you click them.

#### Screenshots (if appropriate)
![Screen Shot 2020-04-03 at 3 07 58 PM](https://user-images.githubusercontent.com/12089658/78396222-f8ff3e00-75bc-11ea-8aaa-3061e181968f.png)
![Screen Shot 2020-04-03 at 3 08 05 PM](https://user-images.githubusercontent.com/12089658/78396232-fbfa2e80-75bc-11ea-971f-9c8ced797c22.png)