### PR TITLE
Annotate course listing page

### DIFF
--- a/site/data/course_annotations.json
+++ b/site/data/course_annotations.json
@@ -1,0 +1,12 @@
+{
+  "12-001-introduction-to-geology-fall-2013": "Traditional course with big tables and image gallery.",
+  "6-042j-mathematics-for-computer-science-spring-2015": "Course with multilevel left nav, lecture videos interspersed (ideal candidate for “show me the lectures” feature), and some interactive assessments.",
+  "16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006": "Crazy course from a metadata perspective (multiple instructors, hundreds of tags, overlapping video typs, etc).",
+  "5-111sc-principles-of-chemical-science-fall-2014" :"Scholar course with multilevel left nav and lecture videos interspersed",
+  "21m-295-american-popular-music-fall-2014": "Should be standard.",
+  "res-3-004-visualizing-materials-science-fall-2017": "Small content in the Supplementary Resource format.",
+  "8-01sc-classical-mechanics-fall-2016": "Scholar course, but more standard than some of the other courses.",
+  "18-06-linear-algebra-spring-2010": "Traditional course with video lectures and 6 course features.",
+  "6-033-computer-system-engineering-spring-2018":"Large left nav (not a scholar course). Was a request where I also asked if we could remove aspects of the left nav (e.g., sub menus).",
+  "8-591j-systems-biology-fall-2014" :"Request to see how instructor insights behaves in Sandbox, it is a multi-menu instructor insights."
+}

--- a/site/layouts/courseindex/section.html
+++ b/site/layouts/courseindex/section.html
@@ -8,8 +8,16 @@
   </article>
   <ul>
     {{ range .Pages }}
-    <li>
-      <a href="{{.Permalink}}">{{.Params.course_title}}</a>
+    <li style="padding-bottom: 5px;">
+      <a href="{{.Permalink}}">
+        {{- range $index, $course_number := .Params.course_info.course_numbers -}}
+        {{- if $index -}},&nbsp;{{- end -}}
+          {{- $course_number -}}
+        {{- end -}}&nbsp;-&nbsp;
+        {{ .Params.course_title}}</a>
+      <div class="pb-2">
+      {{ index .Site.Data.course_annotations .Params.course_id }}
+      </div>
     </li>
     {{ end }}
   </ul>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

just adds some info to our sort of temporary course list

#### How should this be manually tested?

go to `/courses` and you should see annotations for some of the courses and they should all have a course number.


#### Screenshots (if appropriate)

![Screenshot from 2020-04-08 19-07-52](https://user-images.githubusercontent.com/6207644/78841775-40763780-79cc-11ea-9bbb-3a450db16717.png)

![Screenshot from 2020-04-08 19-09-37](https://user-images.githubusercontent.com/6207644/78841868-83380f80-79cc-11ea-8f16-8d03f19ec3c1.png)

┆Attachments: <a href="https://github.com/mitodl/hugo-course-publisher/issues/123">#123 Annotate course listing page</a>
