### PR TITLE
blockquote left-margin

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -22,6 +22,10 @@ body {
   font-family: "Helvetica";
 }
 
+blockquote {
+  margin-left: 2em;
+}
+
 a {
   color: black;
   text-decoration: underline;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/150

#### What's this PR do?
Adds a `left-margin` rule to `blockquote` elements to match current OCW

#### How should this be manually tested?
Run the site, verify that blockquotes like this one are indented:

http://localhost:3000/courses/20-020-introduction-to-biological-engineering-design-spring-2009/sections/syllabus/

#### Screenshots (if appropriate)
![Screen Shot 2020-07-20 at 11 09 45 AM](https://user-images.githubusercontent.com/12089658/87954017-cbf66e80-ca79-11ea-85ec-07e65937ad91.png)
![Screen Shot 2020-07-20 at 11 09 56 AM](https://user-images.githubusercontent.com/12089658/87954028-d0bb2280-ca79-11ea-8bf2-966d17bd03f2.png)