### PR TITLE
fix instructor and course number

### DIFF
--- a/site/layouts/_default/pdf.html
+++ b/site/layouts/_default/pdf.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
-{{ partial "course_section.html" . }}
+{{ partial "chp_partial.html" (dict "partial" "course_section.html" "context" .) }}
 {{ partial "pdf_viewer.html" . }}
 {{ end }}

--- a/site/layouts/_default/section.html
+++ b/site/layouts/_default/section.html
@@ -33,6 +33,6 @@
     </li>
   {{ end }}
 {{ else }}
-{{ partial "course_section.html" . }}
+{{ partial "chp_partial.html" (dict "partial" "course_section.html" "context" .) }}
 {{ end }}
 {{ end }}

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -1,3 +1,3 @@
 {{ define "main" }}
-{{ partial "course_section.html" . }}
+{{ partial "chp_partial.html" (dict "partial" "course_section.html" "context" .) }}
 {{ end }}

--- a/site/layouts/_default/video.html
+++ b/site/layouts/_default/video.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ partial "course_section.html" . }}
+{{ partial "chp_partial.html" (dict "partial" "course_section.html" "context" .) }}
 <div class="video-page">
   <div class="description">
     {{ .Params.about_this_resource_text | safeHTML }}

--- a/site/layouts/_default/videogallery.html
+++ b/site/layouts/_default/videogallery.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ $page := . }}
-{{ partial "course_section.html" . }}
+{{ partial "chp_partial.html" (dict "partial" "course_section.html" "context" .) }}
 {{ range $index, $video := (where .Pages ".Params.layout" "video") }}
   <div class="mb-2 border-light-grey rounded video-gallery-card">
     <a class="video-link" href="{{ $video.Permalink }}">

--- a/site/layouts/partials/course_section.html
+++ b/site/layouts/partials/course_section.html
@@ -1,12 +1,11 @@
 {{ $currentPage := . }}
 {{ $courseId := .Params.course_id }}
-{{ $courseHome := .Page.FirstSection }}
 
 <div class="pb-4 rounded">
   <header>
-    <h5 class="text-muted text-uppercase course-title-section" >{{ $courseHome.Params.course_title }}</h5>
+    <h5 class="text-muted text-uppercase course-title-section" >{{ .Params.course_title }}</h5>
     <h1 class="text-uppercase font-weight-bold">{{ $currentPage.Title }}</h1>
-    {{ partial "course_instructor_number.html" $courseHome }}
+    {{ partial "chp_partial.html" (dict "partial" "course_instructor_number.html" "context" .) }}
     {{ with $currentPage.Params.course_info.subtitle }}
     <span class="subtitle">{{ . }}</span>
     {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/168

#### What's this PR do?
This PR corrects a few spots I missed that need to use `chp_partial.html` to get access to the context of the course home page.

#### How should this be manually tested?
Run the site.  The instructor and course numbers should now be visible from pages other than the course home page.

#### Screenshots (if appropriate)
![Screen Shot 2020-08-03 at 12 46 55 PM](https://user-images.githubusercontent.com/12089658/89206688-a2fcd000-d587-11ea-8f21-86245d9a1984.png)
![Screen Shot 2020-08-03 at 12 47 48 PM](https://user-images.githubusercontent.com/12089658/89206708-aa23de00-d587-11ea-97e2-195a89f01444.png)