### PR TITLE
videogallery / video / pdf bug fix

### DIFF
--- a/site/layouts/course/pdf.html
+++ b/site/layouts/course/pdf.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
-{{ partial "chp_partial.html" (dict "partial" "course_content.html" "context" .) }}
+{{ partial "course_content.html" . }}
 {{ partial "pdf_viewer.html" . }}
 {{ end }}

--- a/site/layouts/course/video.html
+++ b/site/layouts/course/video.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ partial "chp_partial.html" (dict "partial" "course_content.html" "context" .) }}
+{{ partial "course_content.html" . }}
 <div class="video-page">
   <div class="description">
     {{ .Params.about_this_resource_text | safeHTML }}

--- a/site/layouts/course/videogallery.html
+++ b/site/layouts/course/videogallery.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 {{ $page := . }}
-{{ partial "chp_partial.html" (dict "partial" "course_content.html" "context" .) }}
+{{ partial "course_content.html" . }}
 {{ range $index, $video := (where .Pages ".Params.layout" "video") }}
   <div class="mb-2 border-light-grey rounded video-gallery-card">
     <a class="video-link" href="{{ $video.Permalink }}">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/176

#### What's this PR do?
These templates were moved into the `course` type, and they don't need to call partials with the `chp_partial.html` partial.

#### How should this be manually tested?
Run the site, visit http://localhost:3000/courses/14-01sc-principles-of-microeconomics-fall-2011/sections/unit-3-producer-theory/productivity-and-costs/ or any other pdf, videogallery or video page.  You should see the content from the page and not the course home page.