### PR TITLE
fix search environment variable issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ natively.
 ### search
 
 To use the search feature you need set an environment variable to tell the app
-where to find the search API. Write a `.env` file like this:
+where to find the search API. You can write a `.env` file like this:
 
 ```
 SEARCH_API_URL=http://localhost:8063/api/v0/search/
 ```
 
-adjust it if your local open-discussions instance lives at a different URL.
+adjust this if your local open-discussions instance lives at a different URL.
+
+You can also use any other means you like to ensure that the variable is set in
+the environment where webpack will run.
 
 ### docker
 

--- a/src/webpack/webpack.common.js
+++ b/src/webpack/webpack.common.js
@@ -94,7 +94,9 @@ module.exports = {
   },
 
   plugins: [
-    new Dotenv(),
+    new Dotenv({
+      systemvars: true
+    }),
 
     new AssetsPlugin({
       filename:    "webpack.json",


### PR DESCRIPTION
#### What are the relevant tickets?
none

#### What's this PR do?

set dotenv to pull in system variables too

#### How should this be manually tested?

search should work in the deployed environment

