### PR TITLE
limit OCW search to return only courses

### DIFF
--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -1,0 +1,68 @@
+import { LR_TYPE_COURSE } from "./constants"
+
+import {
+  buildSearchQuery,
+  buildSuggestQuery,
+  LEARN_SUGGEST_FIELDS,
+  searchFields
+} from "./search"
+
+describe("search library", () => {
+  it("form a basic text query", () => {
+    const { query } = buildSearchQuery({ text: "Dogs are the best" })
+    expect(query).toStrictEqual({
+      bool: {
+        should: [
+          {
+            bool: {
+              filter: {
+                bool: {
+                  must: [
+                    {
+                      term: {
+                        object_type: LR_TYPE_COURSE
+                      }
+                    },
+                    {
+                      bool: {
+                        should: [
+                          {
+                            multi_match: {
+                              query:  "Dogs are the best",
+                              fields: searchFields(LR_TYPE_COURSE)
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              should: [
+                {
+                  multi_match: {
+                    query:  "Dogs are the best",
+                    fields: searchFields(LR_TYPE_COURSE)
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    })
+  })
+
+  it("should include suggest query, if text", () => {
+    expect(buildSearchQuery({ text: "text!" }).suggest).toStrictEqual(
+      buildSuggestQuery("text!", LEARN_SUGGEST_FIELDS)
+    )
+    expect(buildSearchQuery({}).suggest).toBeUndefined()
+  })
+
+  it("should set from, size values", () => {
+    const query = buildSearchQuery({ from: 10, size: 100 })
+    expect(query.from).toBe(10)
+    expect(query.size).toBe(100)
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #178 

#### What's this PR do?

this basically changes the elasticsearch query generation code to limit the results to just courses, and exclude other learning resources which could be returned otherwise (videos, podcasts, etc).

#### How should this be manually tested?

make sure that on your local instance you have some OCW courses as well as other OCW stuff, and then confirm that after checking out this branch you're only seeing courses in your search results.


#### Screenshots (if appropriate)

![Screenshot from 2020-08-24 16-24-52](https://user-images.githubusercontent.com/6207644/91092817-928bc280-e626-11ea-83b6-5224b8fac132.png)