### PR TITLE
add build:externalcontent command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview:webpack": "npm run start:webpack",
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:pdfjs && npm run build:hugo",
+    "build:externalcontent": "npm run build:webpack && npm run build:pdfjs && hugo -d ../dist -s site -v --theme multi_course --contentDir ",
     "build:netlify": "npm run build:webpack && npm run build:pdfjs && npm run build:hugo:netlify",
     "build:preview": "npm run build:webpack && npm run build:pdfjs && npm run build:hugo:preview",
     "build:hugo": "hugo -d ../dist -s site -v",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/191

#### What's this PR do?
Adds a convenient command to the node build scripts to build the whole site against an external content directory

#### How should this be manually tested?
Build content in `ocw-to-hugo` using the output of [this](https://github.com/mitodl/ocw-to-hugo/pull/66) PR (or master after it merges) and then point to the output directory using the following syntax:

```sh
npm run build:externalcontent -- /path/to/content
```
