### PR TITLE
disable relativeUrls by default

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 languageLang = "en"
 title = "Hugo Course Publisher"
 theme = "multi_course"
-relativeURLs = true
+relativeURLs = false
 
 # RSS, categories and tags disabled for an easy start
 # See configuration options for more details: 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hugo-course-publisher/issues/204

#### What's this PR do?
This PR sets `relativeUrls` to false in the Hugo `config.toml` file.  When building the whole site with output from `ocw-to-hugo` with the `strips3` option enabled, the Hugo build would balloon in memory usage until eventually crashing out.  This is because `strips3` turns every link into an absolute link relative to the site root, which Hugo processes and tries to turn into a relative link.

#### How should this be manually tested?
Sync the entire `open-learning-course-data-production` bucket to your local machine and run `ocw-to-hugo` with the `strips3` option enabled.  Then, run the `hugo-course-publisher` build with the output from this run and ensure you do not get an out of memory error.
