### PR TITLE
hide instructor and course number from section pages

### DIFF
--- a/site/layouts/partials/course_content.html
+++ b/site/layouts/partials/course_content.html
@@ -5,7 +5,6 @@
   <header>
     <h5 class="text-muted text-uppercase course-title-section" >{{ .Params.course_title }}</h5>
     <h1 class="text-uppercase font-weight-bold">{{ $currentPage.Title }}</h1>
-    {{ partial "chp_partial.html" (dict "partial" "course_instructor_number.html" "context" .) }}
     {{ with $currentPage.Params.course_info.subtitle }}
     <span class="subtitle">{{ . }}</span>
     {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/212

#### What's this PR do?
Removes the instructor and course number from pages that aren't the course home page.

#### How should this be manually tested?
Run the site, verify that course number and instructor do not show up on pages that aren't the course home page.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/93821328-6a46b200-fc2c-11ea-9ba0-dc30bbdb6027.png)
![image](https://user-images.githubusercontent.com/12089658/93821409-86e2ea00-fc2c-11ea-98a2-a36c6c0707e8.png)
