### PR TITLE
add the fullwidth-cell shortcode

### DIFF
--- a/site/layouts/shortcodes/fullwidth-cell.html
+++ b/site/layouts/shortcodes/fullwidth-cell.html
@@ -1,0 +1,1 @@
+<div class="position-absolute">{{ .Inner | markdownify }}</div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/219

#### What's this PR do?
This PR, in combination with the output of https://github.com/mitodl/ocw-to-hugo/pull/85, fixes header cells in tables so they do not break the layout of the table.

#### How should this be manually tested?
Run the site with the output of the `ocw-to-hugo` PR above and ensure that the tables are displaying properly.

#### Screenshots (if appropriate)
![Screen Shot 2020-09-22 at 3 34 44 PM](https://user-images.githubusercontent.com/12089658/93929055-44331780-fce9-11ea-9a48-0b073c5a61bd.png)
![Screen Shot 2020-09-22 at 3 35 11 PM](https://user-images.githubusercontent.com/12089658/93929061-45644480-fce9-11ea-9186-13fc1e66bef3.png)

