### PR TITLE
link from topics in search results to a search with that topic

### DIFF
--- a/src/css/learning-resource-card.scss
+++ b/src/css/learning-resource-card.scss
@@ -121,6 +121,7 @@
 
           a {
             color: black;
+            text-decoration: none;
 
             &:hover {
               color: black;

--- a/src/js/components/HomeSearchBox.js
+++ b/src/js/components/HomeSearchBox.js
@@ -3,6 +3,8 @@ import { serializeSearchParams } from "@mitodl/course-search-utils/dist/url_util
 
 import SearchBox from "./SearchBox"
 
+import { SEARCH_URL } from "../lib/constants"
+
 export default function HomeSearchBox() {
   const [text, setText] = useState("")
 
@@ -18,7 +20,7 @@ export default function HomeSearchBox() {
   const onSubmit = useCallback(
     event => {
       event.preventDefault()
-      window.location = `/search/?${serializeSearchParams({
+      window.location = `${SEARCH_URL}?${serializeSearchParams({
         text,
         activeFacets: {}
       })}`

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -2,6 +2,10 @@ import React, { useState, useCallback } from "react"
 import debounce from "lodash.debounce"
 import InfiniteScroll from "react-infinite-scroller"
 import { useCourseSearch } from "@mitodl/course-search-utils"
+import {
+  LR_TYPE_COURSE,
+  LR_TYPE_RESOURCEFILE
+} from "@mitodl/course-search-utils/dist/constants"
 
 import SearchResult from "./SearchResult"
 import SearchBox from "./SearchBox"
@@ -10,10 +14,6 @@ import FilterableFacet from "./FilterableFacet"
 
 import { search } from "../lib/api"
 import { searchResultToLearningResource, SEARCH_LIST_UI } from "../lib/search"
-import {
-  LR_TYPE_COURSE,
-  LR_TYPE_RESOURCEFILE
-} from "@mitodl/course-search-utils/dist/constants"
 
 export const SEARCH_PAGE_SIZE = 10
 

--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -1,12 +1,16 @@
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
+import { serializeSearchParams } from "@mitodl/course-search-utils/dist/url_utils"
+import {
+  LR_TYPE_RESOURCEFILE,
+  LR_TYPE_VIDEO
+} from "@mitodl/course-search-utils/dist/constants"
 
 import Card from "./Card"
 
 import {
   CAROUSEL_IMG_HEIGHT,
-  LR_TYPE_RESOURCEFILE,
-  LR_TYPE_VIDEO,
+  SEARCH_URL,
   readableLearningResources
 } from "../lib/constants"
 import {
@@ -21,14 +25,11 @@ const getClassName = searchResultLayout =>
     searchResultLayout === SEARCH_LIST_UI ? "list-view" : ""
   }`.trim()
 
-const formatTopics = topics =>
-  topics.map((topic, i) => <a key={i}>{topic.name}</a>)
-
-const Subtitle = ({ label, content, htmlClass }) => (
+const Subtitle = ({ label, children, htmlClass }) => (
   <div className="lr-row subtitle">
     <div className={`lr-subtitle ${htmlClass}`}>
       <span className="gray">{label}</span>
-      {content}
+      {children}
     </div>
   </div>
 )
@@ -121,12 +122,26 @@ export function LearningResourceDisplay(props) {
         <div className="lr-row subtitles">
           {object.topics.length > 0 ? (
             <Subtitle
-              content={formatTopics(object.topics)}
               label={`${
                 object.topics.length === 1 ? "Subject" : "Subjects"
               } - `}
               htmlClass="subject"
-            />
+            >
+              {object.topics.map((topic, idx) => (
+                <a
+                  className="topic-link"
+                  key={idx}
+                  href={`${SEARCH_URL}?${serializeSearchParams({
+                    text:         undefined,
+                    activeFacets: {
+                      topics: topic.name
+                    }
+                  })}`}
+                >
+                  {topic.name}
+                </a>
+              ))}
+            </Subtitle>
           ) : null}
         </div>
         {isResource ? (

--- a/src/js/components/SearchResult.test.js
+++ b/src/js/components/SearchResult.test.js
@@ -1,10 +1,15 @@
 import React from "react"
 import { mount } from "enzyme"
+import { serializeSearchParams } from "@mitodl/course-search-utils/dist/url_utils"
+import {
+  LR_TYPE_COURSE,
+  LR_TYPE_RESOURCEFILE
+} from "@mitodl/course-search-utils/dist/constants"
 
 import SearchResult from "./SearchResult"
 
 import { makeLearningResourceResult } from "../factories/search"
-import { LR_TYPE_COURSE, LR_TYPE_RESOURCEFILE } from "../lib/constants"
+import { SEARCH_URL } from "../lib/constants"
 import { getContentIcon, getCoverImageUrl } from "../lib/search"
 
 describe("SearchResult component", () => {
@@ -70,5 +75,22 @@ describe("SearchResult component", () => {
     ).toBe(getCoverImageUrl(object))
     expect(wrapper.find("DrawerImageDiv").exists()).toBeFalsy()
     expect(wrapper.find("LinkedImageDiv").exists()).toBeTruthy()
+  })
+
+  it("should link to the course subjects", () => {
+    const object = makeLearningResourceResult(LR_TYPE_COURSE)
+    const wrapper = render(object)
+
+    wrapper.find(".topic-link").forEach((link, i) => {
+      const { href } = link.props()
+      expect(href).toBe(
+        `${SEARCH_URL}?${serializeSearchParams({
+          text:         undefined,
+          activeFacets: {
+            topics: object.topics[i].name
+          }
+        })}`
+      )
+    })
   })
 })

--- a/src/js/lib/constants.js
+++ b/src/js/lib/constants.js
@@ -44,3 +44,5 @@ export const readableLearningResources = {
 }
 
 export const DISPLAY_DATE_FORMAT = "MMMM D, YYYY"
+
+export const SEARCH_URL = "/search/"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?



#### What's this PR do?

this follows the behavior that we do in Open, where you can click on a topic in the result card to go a search for that topic.

#### How should this be manually tested?

check out the branch and check that you can click on, say, 'physics' on a card and be linked to `/search/?t=Physics`.

