### PR TITLE
set partial collapse list to reveal 4 items

### DIFF
--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -3,22 +3,13 @@
     <tr>
       <td class="px-0 py-2">Instructor(s)</td>
       <td class="px-0 py-2">
-        {{ range $instructor := .Params.course_info.instructors }}
-        <a href="#" class="coming-soon pr-1">
-          {{ $instructor }}
-        </a>
-        {{ end }}
+        {{ partial "partial_collapse_list.html" (dict "list" .Params.course_info.instructors "id" "instructors") }}
       </td>
     </tr>
     <tr>
       <td class="px-0 py-2">Course No.</td>
       <td class="px-0 py-2">
-        {{- range $index, $course_number := .Params.course_info.course_numbers -}}
-        {{- if $index -}},&nbsp;{{- end -}}
-        <a href="#" class="coming-soon">
-          {{- $course_number -}}
-        </a>
-        {{- end -}}
+        {{ partial "partial_collapse_list.html" (dict "list" .Params.course_info.course_numbers "id" "course_numbers") }}
       </td>
     </tr>
   </table>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -1,22 +1,22 @@
 <div class="instructor-and-number">
   <table class="table table-borderless mb-2">
     <tr>
-      <td class="px-0 py-2">Instructor(s)</td>
-      <td class="px-0 py-2">
-        {{ range $index, $instructor := .Params.course_info.instructors }}
+      <td class="px-2 py-2">Instructor(s)</td>
+      <td class="px-2 py-2">
+        {{- range $index, $instructor := .Params.course_info.instructors -}}
         {{- if $index -}},&nbsp;{{- end -}}
-        <a href="#" class="coming-soon pr-1">
+        <a class="px-0" href="#" class="coming-soon pr-1">
           {{- $instructor -}}
         </a>
-        {{ end }}
+        {{- end -}}
       </td>
     </tr>
     <tr>
-      <td class="px-0 py-2">Course No.</td>
-      <td class="px-0 py-2">
+      <td class="px-2 py-2">Course No.</td>
+      <td class="px-2 py-2">
         {{- range $index, $course_number := .Params.course_info.course_numbers -}}
         {{- if $index -}},&nbsp;{{- end -}}
-        <a href="#" class="coming-soon">
+        <a class="px-0" href="#" class="coming-soon">
           {{- $course_number -}}
         </a>
         {{- end -}}

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -3,13 +3,23 @@
     <tr>
       <td class="px-0 py-2">Instructor(s)</td>
       <td class="px-0 py-2">
-        {{ partial "partial_collapse_list.html" (dict "list" .Params.course_info.instructors "id" "instructors") }}
+        {{ range $index, $instructor := .Params.course_info.instructors }}
+        {{- if $index -}},&nbsp;{{- end -}}
+        <a href="#" class="coming-soon pr-1">
+          {{ $instructor }}
+        </a>
+        {{ end }}
       </td>
     </tr>
     <tr>
       <td class="px-0 py-2">Course No.</td>
       <td class="px-0 py-2">
-        {{ partial "partial_collapse_list.html" (dict "list" .Params.course_info.course_numbers "id" "course_numbers") }}
+        {{- range $index, $course_number := .Params.course_info.course_numbers -}}
+        {{- if $index -}},&nbsp;{{- end -}}
+        <a href="#" class="coming-soon">
+          {{- $course_number -}}
+        </a>
+        {{- end -}}
       </td>
     </tr>
   </table>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -6,7 +6,7 @@
         {{ range $index, $instructor := .Params.course_info.instructors }}
         {{- if $index -}},&nbsp;{{- end -}}
         <a href="#" class="coming-soon pr-1">
-          {{ $instructor }}
+          {{- $instructor -}}
         </a>
         {{ end }}
       </td>

--- a/site/layouts/partials/partial_collapse_list.html
+++ b/site/layouts/partials/partial_collapse_list.html
@@ -1,4 +1,4 @@
-{{ if gt (len .list) 2 }}
+{{ if gt (len .list) 4 }}
 <div class="position-relative pr-3">
   <a class="partial-collapse-toggle-link" href="#partial-collapse-container_{{ .id }}" data-toggle="collapse"
     aria-controls="partial-collapse-container_{{ .id }}" aria-expanded="false">

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -14,7 +14,7 @@ $darker-gray: #6f6f6f;
 $border-dark-color: #979797;
 $border-light-color: #b0b0b0;
 $bg-gray: #d5d5d5;
-$partial-collapse-height: 3em;
+$partial-collapse-height: 6em;
 $font-gray-light: #b0b0b0;
 $font-gray-mid: #8a8b8c;
 $card-background: #fff;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/220

#### What's this PR do?
This PR increases `$partial-collapse-height` to `6em` which fully reveals 3 items in a list and partially reveals a fourth.  The threshold has also been changed to 4 items, so a list needs to contain more than 4 items to have this style applied.

#### How should this be manually tested?
Run the site or visit the deploy preview and look at a course like `16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006` that has a lot of instructors and verify that it displays them as noted in the issue above.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/94161374-9a23ce80-fe53-11ea-833f-63e489662f09.png)
![image](https://user-images.githubusercontent.com/12089658/94162006-42d22e00-fe54-11ea-8a8a-54f6e15b0be0.png)
