### PR TITLE
pull in open-style loading animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "ramda": "^0.27.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0-beta.15",
+    "react-content-loader": "^5.1.2",
     "react-dom": "^16.13.1",
     "react-dotdotdot": "1.2.3",
     "react-hot-loader": "^4.12.17",

--- a/src/js/components/Loading.js
+++ b/src/js/components/Loading.js
@@ -1,15 +1,40 @@
 import React from "react"
+import ContentLoader from "react-content-loader"
+import { times } from "ramda"
 
-export default function Loading(props) {
-  const { className } = props
+import Card from "./Card"
 
+export const contentLoaderSpeed = 2
+
+export const AnimatedEmptyCard = () => (
+  <div className="post-content-loader">
+    <Card className="compact-post-summary">
+      <ContentLoader
+        speed={contentLoaderSpeed}
+        style={{ width: "100%", height: "137px" }}
+        width={1000}
+        height={137}
+        preserveAspectRatio="none"
+      >
+        <rect x="0" y="0" rx="5" ry="5" width="60%" height="20" />
+        <rect x="0" y="40" rx="5" ry="5" width="60%" height="16" />
+        <rect x="0" y="58" rx="5" ry="5" width="60%" height="16" />
+        <rect x="0" y="113" rx="5" ry="5" width="170" height="24" />
+        <rect x="66%" y="0" rx="5" ry="5" width="34%" height={128} />
+      </ContentLoader>
+    </Card>
+  </div>
+)
+
+export default function Loading() {
   return (
-    <div className={`loading ${className || ""}`}>
-      <div className="spinner">
-        <div className="bounce1"></div>
-        <div className="bounce2"></div>
-        <div className="bounce3"></div>
-      </div>
+    <div className="card-list-loader">
+      {times(
+        i => (
+          <AnimatedEmptyCard key={i} />
+        ),
+        10
+      )}
     </div>
   )
 }

--- a/src/js/components/Loading.test.js
+++ b/src/js/components/Loading.test.js
@@ -1,22 +1,19 @@
 import React from "react"
 import { shallow } from "enzyme"
 
-import Loading from "./Loading"
+import Loading, { AnimatedEmptyCard } from "./Loading"
 
 describe("Loading", () => {
-  test("should render the right divs", () => {
+  test("should render ten cards", () => {
     const wrapper = shallow(<Loading />)
-    expect(wrapper.find(".loading .spinner").exists()).toBeTruthy()
-    expect(
-      wrapper
-        .find(".spinner")
-        .children()
-        .map(el => el.prop("className"))
-    ).toEqual(["bounce1", "bounce2", "bounce3"])
+    expect(wrapper.find("AnimatedEmptyCard").length).toBe(10)
   })
 
-  test("should let you set a className", () => {
-    const wrapper = shallow(<Loading className="not-loading-lol" />)
-    expect(wrapper.find(".loading.not-loading-lol").exists()).toBeTruthy()
+  test("Card should render what we want", () => {
+    const wrapper = shallow(<AnimatedEmptyCard />)
+
+    expect(wrapper.find("Card").prop("className")).toBe("compact-post-summary")
+    expect(wrapper.find("ContentLoader")).toBeTruthy()
+    expect(wrapper.find("rect").length).toBe(5)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10953,6 +10953,11 @@ react-bootstrap@^1.0.0-beta.15:
     uncontrollable "^7.0.0"
     warning "^4.0.3"
 
+react-content-loader@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-5.1.2.tgz#75dcff30f2651c166c21433484081e7e70b44b6a"
+  integrity sha512-Kr4wWisiL0qcdbzVWZx/puyCfTP1PiTTtR7N4B7mikTeY2wf5TMgMykUQyaEUW422IDUU9VJWfewSm9hIRwTiw==
+
 react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #226

#### What's this PR do?

this replaces the little 'spinner' animation we're currently using with a 'placeholder' animation that is similar to the ones we use in Open.

#### How should this be manually tested?

I think just make sure that the animation is showing up and so on.


#### Screenshots (if appropriate)

![Screenshot from 2020-09-28 12-03-43](https://user-images.githubusercontent.com/6207644/94457566-bc368d00-0182-11eb-8aaf-7d01c23ffddd.png)
