### PR TITLE
downgrade react-dotdotdot

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0-beta.15",
     "react-dom": "^16.13.1",
-    "react-dotdotdot": "^1.3.1",
+    "react-dotdotdot": "1.2.3",
     "react-hot-loader": "^4.12.17",
     "react-infinite-scroller": "^1.2.4",
     "react-test-renderer": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10963,10 +10963,10 @@ react-dom@^16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dotdotdot@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.3.1.tgz#b94324bf66cdb70e4acffe5460e4480a91135e50"
-  integrity sha512-ImqoKTD4ZdyfF/h7jdPCZur01QlZxx3A9/gZSf9mbvseNZwVTvd+dPwi/hg1UTtP+30luy2d5j0KG+XEfdBPLQ==
+react-dotdotdot@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.2.3.tgz#45bb264153cee73471f55c51c8d1542f4880a34f"
+  integrity sha512-lYCHCegi76+kqmgqkii/ma2QqsfA1Slf5jTJYWKgnT3uz8EkPaO9hRDPMDEsDHEBua2qOXSxWCHxVf4N740W1w==
   dependencies:
     object.pick "^1.3.0"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

for #226

#### What's this PR do?

this downgrades the `react-dotdotdot` package to the same version we're using in Open. The newer version doesn't seem to recalculate whether it should truncate or not correctly (only on re-render, not if a hover state changes, for instance). The older version does better, and solves one of the issues listed in #226.

#### How should this be manually tested?

If you check out this branch you should note that hovering over the facet values in the topic picker doesn't cause two lines to appear, like this:

![asdfasdfasdfffasdfasdfff](https://user-images.githubusercontent.com/6207644/94599272-38ea6980-025e-11eb-91eb-dd25fc1e78c9.png)


#### Screenshots (if appropriate)

![asdfasdfasdfffasdfasdffffasdf](https://user-images.githubusercontent.com/6207644/94599295-3daf1d80-025e-11eb-8eb8-3122199cedfd.png)
