### PR TITLE
fix spacing between topic filter and results

### DIFF
--- a/src/css/search-filter.scss
+++ b/src/css/search-filter.scss
@@ -42,16 +42,7 @@
   justify-content: space-between;
 }
 
-.facets,
-.active-search-filters {
-  @include breakpoint(desktop) {
-    width: 90%;
-  }
-}
-
 .facets {
-  margin-bottom: 20px;
-
   .divider {
     padding-top: 20px;
   }

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -105,7 +105,7 @@ export default function SearchPage() {
           {isResourceSearch || !completedInitialLoad ? null : (
             <div className="col-3 mt-3 mt-lg-6"></div>
           )}
-          <div className="search-results col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6 mx-auto">
+          <div className="search-results col-12 col-lg-8 col-xl-8 mt-3 mt-lg-6 mx-auto px-0">
             <div
               className={`search-toggle ${
                 isResourceSearch ? "nofacet" : "facet"
@@ -140,7 +140,7 @@ export default function SearchPage() {
         </div>
         <div className="row">
           {isResourceSearch || !completedInitialLoad ? null : (
-            <div className="col-3 mt-3 mt-lg-6">
+            <div className="col-3 mt-3">
               <FilterableFacet
                 results={facetOptions("topics")}
                 name="topics"
@@ -150,7 +150,7 @@ export default function SearchPage() {
               />
             </div>
           )}
-          <div className="search-results col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6 mx-auto">
+          <div className="search-results col-12 col-lg-8 col-xl-8 mt-3 mx-auto px-0">
             <InfiniteScroll
               hasMore={from + SEARCH_PAGE_SIZE < total}
               loadMore={loadMore}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

for #226 

#### What's this PR do?

this decreases the space between the filter and the search results to be more in line with the designs (look [here](https://projects.invisionapp.com/d/main#/console/18609637/430757993/inspect) for instance).

#### How should this be manually tested?

just check out the branch and make sure the spacing is more in line with the design.

#### Screenshots (if appropriate)

![Screenshot from 2020-09-29 14-53-16](https://user-images.githubusercontent.com/6207644/94602990-a1881500-0263-11eb-9402-8b552a80b1cb.png)

