### PR TITLE
fix search issue w/ loader

### DIFF
--- a/src/js/components/Loading.js
+++ b/src/js/components/Loading.js
@@ -38,3 +38,17 @@ export default function Loading() {
     </div>
   )
 }
+
+export function Spinner(props) {
+  const { className } = props
+
+  return (
+    <div className={`loading ${className || ""}`}>
+      <div className="spinner">
+        <div className="bounce1"></div>
+        <div className="bounce2"></div>
+        <div className="bounce3"></div>
+      </div>
+    </div>
+  )
+}

--- a/src/js/components/Loading.test.js
+++ b/src/js/components/Loading.test.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { shallow } from "enzyme"
 
-import Loading, { AnimatedEmptyCard } from "./Loading"
+import Loading, { AnimatedEmptyCard, Spinner } from "./Loading"
 
 describe("Loading", () => {
   test("should render ten cards", () => {
@@ -15,5 +15,23 @@ describe("Loading", () => {
     expect(wrapper.find("Card").prop("className")).toBe("compact-post-summary")
     expect(wrapper.find("ContentLoader")).toBeTruthy()
     expect(wrapper.find("rect").length).toBe(5)
+  })
+
+  describe("Spinner", () => {
+    test("should render the right divs", () => {
+      const wrapper = shallow(<Spinner />)
+      expect(wrapper.find(".loading .spinner").exists()).toBeTruthy()
+      expect(
+        wrapper
+          .find(".spinner")
+          .children()
+          .map(el => el.prop("className"))
+      ).toEqual(["bounce1", "bounce2", "bounce3"])
+    })
+
+    test("should let you set a className", () => {
+      const wrapper = shallow(<Spinner className="not-loading-lol" />)
+      expect(wrapper.find(".loading.not-loading-lol").exists()).toBeTruthy()
+    })
   })
 })

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -9,7 +9,7 @@ import {
 
 import SearchResult from "./SearchResult"
 import SearchBox from "./SearchBox"
-import Loading from "./Loading"
+import Loading, { Spinner } from "./Loading"
 import FilterableFacet from "./FilterableFacet"
 
 import { search } from "../lib/api"
@@ -155,7 +155,7 @@ export default function SearchPage() {
               hasMore={from + SEARCH_PAGE_SIZE < total}
               loadMore={loadMore}
               initialLoad={false}
-              loader={completedInitialLoad ? <Loading /> : null}
+              loader={completedInitialLoad ? <Spinner /> : null}
             >
               {completedInitialLoad ? (
                 results.length === 0 ? (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

fix an issue where the loading placeholder was always being shown below the search results. This was happening because I was inadvertantly passing the same `<Loader />` component in to the `<InfiniteScroll>` component and using it as a loading placeholder.

To fix it, I brought the spinner we had back to use for showing at the end of the search results and keep the loading placeholder just for the initial load.

#### How should this be manually tested?

use the course search and then scroll down, you should see the loading placeholder on first load but then after that you should just see a simple spinner while the next page is being loaded.

#### Screenshots (if appropriate)


![Screenshot from 2020-09-30 14-34-15](https://user-images.githubusercontent.com/6207644/94725634-158cf080-032a-11eb-8c4f-c08766b6916c.png)
