### PR TITLE
fix input placeholder issues in firefox

### DIFF
--- a/src/css/search-filter.scss
+++ b/src/css/search-filter.scss
@@ -24,6 +24,7 @@
 
     &::placeholder {
       color: $font-gray;
+      line-height: unset;
     }
   }
 

--- a/src/css/search.scss
+++ b/src/css/search.scss
@@ -30,10 +30,14 @@
   input {
     border: 1px solid $border-light-color;
     height: 50px;
+
+    &::placeholder {
+      line-height: revert !important;
+    }
   }
 
   i.material-icons {
-    top: 25%;
+    top: 21%;
     left: 5px;
     color: $font-gray-light;
     cursor: pointer;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #226 

#### What's this PR do?

this fixes an issue where the placeholders are located strangely in the inputs in firefox (not in chrome). this is what it looks like:

![Screenshot from 2020-10-01 11-01-55](https://user-images.githubusercontent.com/6207644/94826707-9654f680-03d5-11eb-969a-1553ff0ec61c.png)

this PR just applies some CSS to fix it (hackily).

#### How should this be manually tested?

just check out the branch and make sure the placeholders look good I think.

#### Screenshots (if appropriate)

![Screenshot from 2020-10-01 11-00-38](https://user-images.githubusercontent.com/6207644/94826556-6e659300-03d5-11eb-9139-ae8c82221620.png)
![Screenshot from 2020-10-01 11-00-32](https://user-images.githubusercontent.com/6207644/94826559-6e659300-03d5-11eb-964c-4d176c4232c8.png)

