### PR TITLE
If CDN_PREFIX is not set, don't use a CDN URL

### DIFF
--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -418,7 +418,9 @@ export const getResourceUrl = result => {
     // Non-page results should have full URLs, convert to CDN if it's an S3 URL
     try {
       const originalUrl = new URL(result.url)
-      const useCDN = originalUrl.hostname.match(/s3\.amazonaws\.com/)
+      const useCDN =
+        originalUrl.hostname.match(/s3\.amazonaws\.com/) &&
+        process.env["CDN_PREFIX"]
       return useCDN ? `/coursemedia${originalUrl.pathname}` : result.url
     } catch {
       return result.url

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -418,10 +418,10 @@ export const getResourceUrl = result => {
     // Non-page results should have full URLs, convert to CDN if it's an S3 URL
     try {
       const originalUrl = new URL(result.url)
+      const cdnPrefix = process.env["CDN_PREFIX"]
       const useCDN =
-        originalUrl.hostname.match(/s3\.amazonaws\.com/) &&
-        process.env["CDN_PREFIX"]
-      return useCDN ? `/coursemedia${originalUrl.pathname}` : result.url
+        originalUrl.hostname.match(/s3\.amazonaws\.com/) && cdnPrefix
+      return useCDN ? `${cdnPrefix}${originalUrl.pathname}` : result.url
     } catch {
       return result.url
     }

--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -130,23 +130,51 @@ describe("search library", () => {
       CONTENT_TYPE_PAGE,
       "18-23",
       "mech_engineering",
+      false,
+      "/courses/18-23/sections/mech_engineering/"
+    ],
+    [
+      CONTENT_TYPE_PAGE,
+      "18-23",
+      "mech_engineering",
+      true,
       "/courses/18-23/sections/mech_engineering/"
     ],
     [
       CONTENT_TYPE_PDF,
       "https://s3.amazonaws.com/18-23/test.pdf",
       "shortlink1",
+      false,
+      "https://s3.amazonaws.com/18-23/test.pdf"
+    ],
+    [
+      CONTENT_TYPE_PDF,
+      "https://s3.amazonaws.com/18-23/test.pdf",
+      "shortlink1",
+      true,
       "/coursemedia/18-23/test.pdf"
     ],
     [
       CONTENT_TYPE_VIDEO,
       "https://youtube.com/?s=2335",
       null,
+      false,
       "https://youtube.com/?s=2335"
     ],
-    [CONTENT_TYPE_VIDEO, "/relative/url", null, "/relative/url"]
-  ].forEach(([contentType, url, shortUrl, expectedUrl]) => {
-    it(`should return correct url for content type ${contentType} `, () => {
+    [
+      CONTENT_TYPE_VIDEO,
+      "https://youtube.com/?s=2335",
+      null,
+      true,
+      "https://youtube.com/?s=2335"
+    ],
+    [CONTENT_TYPE_VIDEO, "/relative/url", null, false, "/relative/url"],
+    [CONTENT_TYPE_VIDEO, "/relative/url", null, true, "/relative/url"]
+  ].forEach(([contentType, url, shortUrl, hasCdn, expectedUrl]) => {
+    it(`should return correct url for content type ${contentType} if the cdn is ${
+      hasCdn ? "" : "not "
+    }set`, () => {
+      process.env["CDN_PREFIX"] = hasCdn ? "https://cdn.example.com" : null
       const result = {
         url,
         short_url:    shortUrl,

--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -130,51 +130,51 @@ describe("search library", () => {
       CONTENT_TYPE_PAGE,
       "18-23",
       "mech_engineering",
-      false,
+      null,
       "/courses/18-23/sections/mech_engineering/"
     ],
     [
       CONTENT_TYPE_PAGE,
       "18-23",
       "mech_engineering",
-      true,
+      "https://cdn.example.com",
       "/courses/18-23/sections/mech_engineering/"
     ],
     [
       CONTENT_TYPE_PDF,
       "https://s3.amazonaws.com/18-23/test.pdf",
       "shortlink1",
-      false,
+      null,
       "https://s3.amazonaws.com/18-23/test.pdf"
     ],
     [
       CONTENT_TYPE_PDF,
       "https://s3.amazonaws.com/18-23/test.pdf",
       "shortlink1",
-      true,
-      "/coursemedia/18-23/test.pdf"
+      "https://cdn.example.com",
+      "https://cdn.example.com/18-23/test.pdf"
     ],
     [
       CONTENT_TYPE_VIDEO,
       "https://youtube.com/?s=2335",
       null,
-      false,
+      "",
       "https://youtube.com/?s=2335"
     ],
     [
       CONTENT_TYPE_VIDEO,
       "https://youtube.com/?s=2335",
       null,
-      true,
+      "/coursemedia",
       "https://youtube.com/?s=2335"
     ],
     [CONTENT_TYPE_VIDEO, "/relative/url", null, false, "/relative/url"],
-    [CONTENT_TYPE_VIDEO, "/relative/url", null, true, "/relative/url"]
-  ].forEach(([contentType, url, shortUrl, hasCdn, expectedUrl]) => {
+    [CONTENT_TYPE_VIDEO, "/relative/url", null, "/coursemedia", "/relative/url"]
+  ].forEach(([contentType, url, shortUrl, cdnPrefix, expectedUrl]) => {
     it(`should return correct url for content type ${contentType} if the cdn is ${
-      hasCdn ? "" : "not "
+      cdnPrefix ? "" : "not "
     }set`, () => {
-      process.env["CDN_PREFIX"] = hasCdn ? "https://cdn.example.com" : null
+      process.env["CDN_PREFIX"] = cdnPrefix
       const result = {
         url,
         short_url:    shortUrl,

--- a/src/js/test_setup.js
+++ b/src/js/test_setup.js
@@ -36,5 +36,6 @@ Object.defineProperty(window, "location", {
 
 process.env = {
   ...process.env,
-  SEARCH_API_URL: "http://search-the-planet.example.com/search"
+  SEARCH_API_URL: "http://search-the-planet.example.com/search",
+  CDN_PREFIX:     null
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #238 

#### What's this PR do?
If `CDN_PREFIX` environment variable is not set, the S3 URL is left alone

#### How should this be manually tested?
- If you don't have this data set up already, run `sync_ocw_courses(course_prefixes=["PROD/6/6.046/Fall_2005/6-046j-introduction-to-algorithms-sma-5503-fall-2005/"], blocklist=[], force_overwrite=True, upload_to_s3=True)` to populate that course in the resources list
- Go to `/search`, click "Resources" and search for "6-046j".
- Hover over the link for the PDF item in the search results. If you have set `CDN_PREFIX`, it should start with `/coursemedia`. If not, it should be a regular S3 link
