### PR TITLE
Fix React warning for key prop

### DIFF
--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -155,7 +155,7 @@ export default function SearchPage() {
               hasMore={from + SEARCH_PAGE_SIZE < total}
               loadMore={loadMore}
               initialLoad={false}
-              loader={completedInitialLoad ? <Spinner /> : null}
+              loader={completedInitialLoad ? <Spinner key="spinner" /> : null}
             >
               {completedInitialLoad ? (
                 results.length === 0 ? (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
I saw this warning on master:
![Screenshot from 2020-10-02 14-46-47](https://user-images.githubusercontent.com/863262/94959089-9846b480-04be-11eb-9a77-8b7204219a55.png)

I added the `key` prop to the `<Spinner />` component and the warning went away. It looks like `InfiniteScroll` adds the `loader` prop value to a list of values to be passed to render which is probably where the error comes from. The [InfiniteScroll docs](https://github.com/danbovey/react-infinite-scroller#readme) say that you need a key prop when passing in a loader component.

#### How should this be manually tested?
You shouldn't see a warning when viewing the course search page. You should see it on master.
