### PR TITLE
Fix zip memory issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ site
 dist
 node_modules
 s3-courses
+zips

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+site
+dist
+node_modules
+s3-courses

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ site/content/courses/*
 !site/content/courses/_index.md
 ocw-to-hugo.*.log
 *.tgz
+zips
 
 # Unit test / coverage reports
 htmlcov/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM node:12.13.0
 # update and upgrade libraries
 RUN apt-get -qq update \
     && apt-get -qq upgrade \
-	&& rm -rf /var/lib/apt/lists/ \
 	&& apt-get -qq clean
+
+RUN apt-get install zip -y
 
 COPY ./package.json /usr/share/
 COPY ./yarn.lock /usr/share/

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -7,7 +7,7 @@ const execFile = util.promisify(require("child_process").execFile)
 const rimraf = util.promisify(require("rimraf"))
 const tmp = require("tmp")
 
-const { directoryExists } = require("../src/js/helpers")
+const { directoryExists, iterateTree } = require("../src/js/helpers")
 const newProgressBar = () => {
   return new cliProgress.SingleBar(
     {
@@ -42,25 +42,6 @@ const options = yargs
 const distPath = options.dist
 const coursesPath = options.courses
 const zipsPath = options.zips
-
-// Walk a tree and produce { root, relPath, file } for each file found
-async function* iterateTree(rootPath, relPath = ".") {
-  const files = await fsPromises.readdir(path.join(rootPath, relPath))
-  for (const file of files) {
-    const absFile = path.join(rootPath, relPath, file)
-    const stat = await fsPromises.lstat(absFile)
-    if (stat.isDirectory()) {
-      for await (const item of iterateTree(
-        rootPath,
-        path.join(relPath, file)
-      )) {
-        yield item
-      }
-    } else if (stat.isFile()) {
-      yield { root: rootPath, relPath, file }
-    }
-  }
-}
 
 // clear out the distribution path and run the webpack build
 const run = async () => {

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -78,9 +78,16 @@ const run = async () => {
   }
 
   const hugoProgress = newProgressBar()
-  const courses = (await fsPromises.readdir(coursesPath)).filter(
-    course => !course.startsWith(".")
-  )
+  const courses = []
+  for (const filename of await fsPromises.readdir(coursesPath)) {
+    const absPath = path.join(coursesPath, filename)
+    if (
+      !filename.startsWith(".") &&
+      (await fsPromises.lstat(absPath)).isDirectory()
+    ) {
+      courses.push(filename)
+    }
+  }
 
   if (courses.length <= 0) {
     console.error(`No courses found`)

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -107,7 +107,6 @@ const run = async () => {
   const webpackFiles = []
   for await (const { root, relPath, file} of iterateTree(distPath)) {
     if (!file.startsWith(".")) {
-      // TODO: is this necessary? Are we only looking to exclude . and ..?
       webpackFiles.push({root, relPath, file})
     }
   }

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -1,7 +1,6 @@
 const yargs = require("yargs")
 const fsPromises = require("fs").promises
 const path = require("path")
-const os = require("os")
 const cliProgress = require("cli-progress")
 const util = require('util')
 const execFile = util.promisify(require('child_process').execFile)
@@ -77,7 +76,7 @@ const run = async () => {
   await rimraf(distPath)
   const { error } = await execFile("npm", ["run", "build:webpack"])
   if (error) {
-    throw new Error("Webpack build failed", error)
+    throw error
   }
 
   // remove existing zips
@@ -122,7 +121,7 @@ const run = async () => {
         "-d", tmpDir, "-s", "site", "--theme", "single_course", "--contentDir", path.join("..", coursesPath, course)
       ])
       if (error) {
-        throw new Error(error)
+        throw error
       }
 
       // create the archive
@@ -143,7 +142,7 @@ const run = async () => {
       const zipPath = path.resolve(zipsPath, `${course}.zip`)
       const {error: zipError} = await execFile("zip", [zipPath, ".", "-r", "-q"], {cwd: tmpDir})
       if (zipError) {
-        throw new Error(zipError)
+        throw zipError
       }
       hugoProgress.increment()
     } finally {

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -36,12 +36,12 @@ const options = yargs
     alias:        "zips",
     describe:     "zip output path",
     type:         "string",
-    demandOption: true
+    demandOption: false
   }).argv
 
 const distPath = options.dist
 const coursesPath = options.courses
-const zipsPath = options.zips
+const zipsPath = options.zips || "zips"
 
 // clear out the distribution path and run the webpack build
 const run = async () => {

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -94,8 +94,7 @@ const run = async () => {
 
   const hugoProgress = newProgressBar()
   const courses = (await fsPromises.readdir(coursesPath))
-    // TODO: what is this for? Are we excluding any course with a dot when we just want to exclude . and ..?
-    .filter(course => !course.includes("."))
+    .filter(course => !course.startsWith("."))
 
   if (courses.length <= 0) {
     console.error(`No courses found`)

--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -1,13 +1,12 @@
 const yargs = require("yargs")
-const fs = require("fs")
-const walk = require("walk")
-const tmp = require("tmp")
-tmp.setGracefulCleanup()
-const rimraf = require("rimraf")
-const archiver = require("archiver")
+const fsPromises = require("fs").promises
 const path = require("path")
+const os = require("os")
 const cliProgress = require("cli-progress")
-const shell = require("shelljs")
+const util = require('util')
+const execFile = util.promisify(require('child_process').execFile)
+const rimraf = util.promisify(require("rimraf"))
+const tmp = require("tmp")
 
 const { directoryExists } = require("../src/js/helpers")
 const newProgressBar = () => {
@@ -45,108 +44,116 @@ const distPath = options.dist
 const coursesPath = options.courses
 const zipsPath = options.zips
 
-// clear out the distribution path and run the webpack build
-rimraf.sync(distPath)
-if (shell.exec("npm run build:webpack").code !== 0) {
-  console.error("Webpack build failed")
-  process.exit(1)
-}
 
-// remove existing zips
-rimraf.sync(zipsPath)
-fs.mkdirSync(zipsPath, { recursive: true })
-
-// ensure dist and courses are directories that exist
-if (!directoryExists(distPath) || !directoryExists(coursesPath)) {
-  console.error(
-    `Path not found - dist exists: ${directoryExists(
-      distPath
-    )} courses exists: ${directoryExists(coursesPath)}`
-  )
-  process.exit(1)
-}
-
-// gather files from the webpack build
-let webpackFiles = []
-walk.walk(distPath, {
-  listeners: {
-    file: (root, fileStats, next) => {
-      // add each file to a list
-      webpackFiles.push({
-        root: root,
-        name: fileStats.name
-      })
-      next()
-    },
-    end: () => {
-      // filter out hidden files
-      webpackFiles = webpackFiles.filter(file => !file.name.startsWith("."))
-      const hugoProgress = newProgressBar()
-      const archiveProgress = newProgressBar()
-      let archiveStarted = false
-      const courses = fs
-        .readdirSync(coursesPath)
-        .filter(course => !course.includes("."))
-      if (courses.length <= 0) {
-        console.error(`No courses found`)
-        process.exit(1)
+// Walk a tree and produce { root, relPath, file } for each file found
+async function* iterateTree(rootPath, relPath = ".") {
+  const files = await fsPromises.readdir(path.join(rootPath, relPath))
+  for (const file of files) {
+    const absFile = path.join(rootPath, relPath, file)
+    const stat = await fsPromises.lstat(absFile)
+    if (stat.isDirectory()) {
+      for await (const item of iterateTree(rootPath, path.join(relPath, file))) {
+        yield item
       }
-      console.log("Generating Hugo sites...")
-      hugoProgress.start(courses.length, 0)
-      courses.forEach(course => {
-        // run the hugo build
-        const tmpDir = tmp.dirSync({
-          prefix: "dist"
-        }).name
-        if (
-          shell.exec(
-            `hugo -d ${tmpDir} -s site --theme single_course --contentDir ${path.join(
-              "..",
-              coursesPath,
-              course
-            )} --quiet`
-          ).code === 0
-        ) {
-          hugoProgress.increment()
-          // create the archive
-          const archive = archiver("zip")
-          // add the webpack files
-          webpackFiles.forEach(file => {
-            archive.file(path.join(file.root, file.name), {
-              name: path.join(
-                file.root.replace(new RegExp(`${distPath}/?`, "g"), ""),
-                file.name
-              )
-            })
-          })
-          // add the course files
-          walk.walk(tmpDir, {
-            listeners: {
-              file: (root, fileStats, next) => {
-                archive.file(path.join(root, fileStats.name), {
-                  name: path.join(root.replace(tmpDir, ""), fileStats.name)
-                })
-                next()
-              },
-              end: () => {
-                // walk seems to call this after all files have been added for every course
-                if (!archiveStarted) {
-                  console.log("Archiving courses...")
-                  archiveProgress.start(courses.length, 1)
-                  archiveStarted = true
-                } else {
-                  archiveProgress.increment()
-                }
-                const output = fs.createWriteStream(
-                  path.join(zipsPath, `${course}.zip`)
-                )
-                archive.pipe(output)
-                archive.finalize()
-              }
-            }
-          })
-        }
-      })
+    } else if (stat.isFile()) {
+      yield { root: rootPath, relPath, file }
     }
   }
+}
+
+// clear out the distribution path and run the webpack build
+const run = async () => {
+  if ((await execFile("which", ["zip"])).error) {
+    throw new Error("Unable to find zip binary")
+  }
+
+  const baseDir = path.resolve(coursesPath, "..", "..")
+  const relative = path.relative(baseDir, zipsPath)
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    // make sure zips are not picked up by hugo, causing a blowup in file size
+    throw new Error("zips path must not be within hugo course area, two parent directories above courses directory")
+  }
+
+  await rimraf(distPath)
+  const { error } = await execFile("npm", ["run", "build:webpack"])
+  if (error) {
+    throw new Error("Webpack build failed", error)
+  }
+
+  // remove existing zips
+  await rimraf(zipsPath)
+  await fsPromises.mkdir(zipsPath, {recursive: true})
+
+  // ensure dist and courses are directories that exist
+  const distExists = await directoryExists(distPath)
+  const coursesExists = await directoryExists(coursesPath)
+  if (!distExists || !coursesExists) {
+    throw new Error(
+      `Path not found - dist exists: ${distExists} courses exists: ${coursesExists}`
+    )
+  }
+
+  const hugoProgress = newProgressBar()
+  const courses = (await fsPromises.readdir(coursesPath))
+    // TODO: what is this for? Are we excluding any course with a dot when we just want to exclude . and ..?
+    .filter(course => !course.includes("."))
+
+  if (courses.length <= 0) {
+    console.error(`No courses found`)
+    process.exit(1)
+  }
+  console.log("Generating Hugo sites...")
+
+  const webpackFiles = []
+  for await (const { root, relPath, file} of iterateTree(distPath)) {
+    if (!file.startsWith(".")) {
+      // TODO: is this necessary? Are we only looking to exclude . and ..?
+      webpackFiles.push({root, relPath, file})
+    }
+  }
+
+  hugoProgress.start(courses.length, 0)
+  for (const course of courses) {
+    // run the hugo build
+    const tmpDir = tmp.dirSync({
+      prefix: "dist"
+    }).name
+    try {
+      const {error} = await execFile("hugo", [
+        "-d", tmpDir, "-s", "site", "--theme", "single_course", "--contentDir", path.join("..", coursesPath, course)
+      ])
+      if (error) {
+        throw new Error(error)
+      }
+
+      // create the archive
+
+      // add the webpack files
+      for (const {root, relPath, file} of webpackFiles) {
+        await fsPromises.mkdir(path.join(tmpDir, relPath), {recursive: true})
+        await fsPromises.copyFile(path.join(root, relPath, file), path.join(tmpDir, relPath, file))
+      }
+      // add the course files
+
+      const courseRoot = path.join(coursesPath, course)
+      for await (const { relPath, file} of iterateTree(courseRoot)) {
+        await fsPromises.mkdir(path.join(tmpDir, relPath), {recursive: true})
+        await fsPromises.copyFile(path.join(courseRoot, relPath, file), path.join(tmpDir, relPath, file))
+      }
+
+      const zipPath = path.resolve(zipsPath, `${course}.zip`)
+      const {error: zipError} = await execFile("zip", [zipPath, ".", "-r", "-q"], {cwd: tmpDir})
+      if (zipError) {
+        throw new Error(zipError)
+      }
+      hugoProgress.increment()
+    } finally {
+      await rimraf(tmpDir)
+    }
+  }
+}
+
+run().catch(err => {
+  console.error("Error:", err)
+  process.exit(1)
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   app:
     build: .
+    env_file:
+      - .env
     container_name: hugo-course-publisher
     ports:
       - "3000:3000"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:hugo:debug": "hugo -d ../dist -s site -v --templateMetrics --debug",
     "build:pdfjs": "./build-scripts/build-pdfjs.sh",
     "build:webpack": "cross-env NODE_ENV=production webpack --config src/webpack/webpack.prod.js",
-    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z zips",
+    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z ${COURSE_ZIPS_DESTINATION:-zips}",
     "import:ocw": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content",
     "import:ocw:download": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content -c $OCW_TO_HUGO_COURSES_JSON --download",
     "import:ocw:strips3": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content --strips3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webpack:stats": "NODE_ENV=production webpack --config src/webpack/webpack.prod.js --profile --json > stats.json",
     "webpack:analyze": "webpack-bundle-analyzer stats.json dist",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi $PWD/'build-scripts/**/*.js' $PWD/'src/**/*.js' $PWD/'src/**/*.scss'",
-    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'src/**/*.js' $PWD/'src/**/*.scss'",
+    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'build-scripts/**/*.js' $PWD/'src/**/*.js' $PWD/'src/**/*.scss'",
     "scss_lint": "node ./node_modules/sass-lint/bin/sass-lint.js --verbose --no-exit ./src",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:hugo:debug": "hugo -d ../dist -s site -v --templateMetrics --debug",
     "build:pdfjs": "./build-scripts/build-pdfjs.sh",
     "build:webpack": "cross-env NODE_ENV=production webpack --config src/webpack/webpack.prod.js",
-    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z site/static/zips",
+    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z zips",
     "import:ocw": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content",
     "import:ocw:download": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content -c $OCW_TO_HUGO_COURSES_JSON --download",
     "import:ocw:strips3": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content --strips3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:hugo:debug": "hugo -d ../dist -s site -v --templateMetrics --debug",
     "build:pdfjs": "./build-scripts/build-pdfjs.sh",
     "build:webpack": "cross-env NODE_ENV=production webpack --config src/webpack/webpack.prod.js",
-    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z ${COURSE_ZIPS_DESTINATION:-zips}",
+    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z $COURSE_ZIPS_DESTINATION",
     "import:ocw": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content",
     "import:ocw:download": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content -c $OCW_TO_HUGO_COURSES_JSON --download",
     "import:ocw:strips3": "ocw-to-hugo -i $OCW_TO_HUGO_INPUT -o site/content --strips3",

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1,11 +1,11 @@
-const fs = require("fs")
+const fsPromises = require("fs").promises
 
-const directoryExists = directory => {
-  return (
-    directory &&
-    fs.existsSync(directory) &&
-    fs.lstatSync(directory).isDirectory()
-  )
+const directoryExists = async directory => {
+  try {
+    return (await fsPromises.lstat(directory)).isDirectory()
+  } catch (err) {
+    return false
+  }
 }
 
 module.exports = {

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1,4 +1,24 @@
 const fsPromises = require("fs").promises
+const path = require("path")
+
+// Walk a tree and produce { root, relPath, file } for each file found
+async function* iterateTree(rootPath, relPath = ".") {
+  const files = await fsPromises.readdir(path.join(rootPath, relPath))
+  for (const file of files) {
+    const absFile = path.join(rootPath, relPath, file)
+    const stat = await fsPromises.lstat(absFile)
+    if (stat.isDirectory()) {
+      for await (const item of iterateTree(
+        rootPath,
+        path.join(relPath, file)
+      )) {
+        yield item
+      }
+    } else if (stat.isFile()) {
+      yield { root: rootPath, relPath, file }
+    }
+  }
+}
 
 const directoryExists = async directory => {
   try {
@@ -9,5 +29,6 @@ const directoryExists = async directory => {
 }
 
 module.exports = {
-  directoryExists
+  directoryExists,
+  iterateTree
 }

--- a/src/js/helpers.test.js
+++ b/src/js/helpers.test.js
@@ -1,0 +1,19 @@
+import { iterateTree } from "./helpers"
+
+describe("helper functions", () => {
+  it("iterates over a directory tree and yields files from it", async () => {
+    const items = []
+    for await (const item of iterateTree(__dirname)) {
+      items.push(item)
+    }
+    expect(items.filter(({ file }) => file === "helpers.js")).toEqual([
+      {
+        file:    "helpers.js",
+        relPath: ".",
+        root:    __dirname
+      }
+    ])
+    // items will include everything in the src/js tree, so just make sure there's something there
+    expect(items.length).toBeGreaterThan(5)
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #195 

#### What's this PR do?
This fixes an issue where zips were populated within the area that hugo picked up files, causing a feedback loop which ran out of memory. I also changed the zip processing to use the zip command in case there were any memory leak issues with archiver.

#### How should this be manually tested?
Run `npm run build:zips` and verify the output zip files look right. This took an hour on my laptop, though it could be faster on other hardware, and we could run tasks in parallel in a future PR if necessary.
