### PR TITLE
add department facet to search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ site/static/zips
 site/content/courses/*
 !site/content/courses/_index.md
 ocw-to-hugo.*.log
+*.tgz
 
 # Unit test / coverage reports
 htmlcov/

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
-    "@mitodl/course-search-utils": "^1.0.4",
+    "@mitodl/course-search-utils": "^1.0.5",
     "@mitodl/ocw-to-hugo": "1.0.3",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",

--- a/src/js/components/FilterableFacet.js
+++ b/src/js/components/FilterableFacet.js
@@ -66,7 +66,7 @@ function FilterableSearchFacet(props) {
   }
 
   return results && results.buckets && results.buckets.length === 0 ? null : (
-    <div className="facets filterable-facet">
+    <div className="facets filterable-facet pb-3">
       <div
         className="filter-section-title"
         onClick={() => setShowFacetList(!showFacetList)}

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -29,6 +29,7 @@ export default function SearchPage() {
         // Default is LR_TYPE_ALL, don't want that here. course or resourcefile only
         activeFacets["type"] = [LR_TYPE_COURSE]
       }
+
       const newResults = await search({
         text,
         from,
@@ -146,6 +147,13 @@ export default function SearchPage() {
                 name="topics"
                 title="Topics"
                 currentlySelected={activeFacets["topics"] || []}
+                onUpdate={onUpdateFacets}
+              />
+              <FilterableFacet
+                results={facetOptions("department_name")}
+                name="department_name"
+                title="Department"
+                currentlySelected={activeFacets["department_name"] || []}
                 onUpdate={onUpdateFacets}
               />
             </div>

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -9,6 +9,7 @@ import {
   LR_TYPE_COURSE,
   LR_TYPE_RESOURCEFILE
 } from "@mitodl/course-search-utils/dist/constants"
+import FilterableFacet from "./FilterableFacet"
 
 import SearchPage, { SEARCH_PAGE_SIZE } from "./SearchPage"
 
@@ -277,5 +278,18 @@ describe("SearchPage component", () => {
     await resolveSearch()
     wrapper.update()
     expect(wrapper.find("Loading").exists()).toBeFalsy()
+  })
+
+  test("should render a FilterableFacet for topic, department", async () => {
+    const wrapper = await render()
+    await resolveSearch()
+    wrapper.update()
+    const [topic, department] = wrapper.find(FilterableFacet)
+    expect(topic.props.name).toEqual("topics")
+    expect(topic.props.title).toEqual("Topics")
+    expect(topic.props.currentlySelected).toEqual([])
+    expect(department.props.name).toEqual("department_name")
+    expect(department.props.title).toEqual("Department")
+    expect(department.props.currentlySelected).toEqual([])
   })
 })

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -25,13 +25,15 @@ export const RESOURCE_QUERY_NESTED_FIELDS = [
   "runs.year",
   "runs.semester",
   "runs.level",
-  "runs.instructors^5"
+  "runs.instructors^5",
+  "department_name"
 ]
 
 export const RESOURCEFILE_QUERY_FIELDS = [
   "content",
   "title",
-  "short_description"
+  "short_description",
+  "department_name"
 ]
 
 export const LR_TYPE_ALL = [
@@ -81,7 +83,8 @@ const COURSE_QUERY_FIELDS = [
   "platform",
   "course_id",
   "coursenum^5",
-  "offered_by"
+  "offered_by",
+  "department_name"
 ]
 const VIDEO_QUERY_FIELDS = [
   "title.english^3",

--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -15,6 +15,7 @@ import {
   getResultUrl,
   LEARN_SUGGEST_FIELDS,
   RESOURCE_QUERY_NESTED_FIELDS,
+  RESOURCEFILE_QUERY_FIELDS,
   searchFields
 } from "./search"
 import { makeLearningResourceResult } from "../factories/search"
@@ -55,7 +56,7 @@ describe("search library", () => {
             query: {
               multi_match: {
                 query:  "Dogs are the best",
-                fields: ["content", "title", "short_description"]
+                fields: RESOURCEFILE_QUERY_FIELDS
               }
             },
             score_mode: "avg"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mitodl/course-search-utils@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.0.4.tgz#a70c0253db0beab03d42e0b8a01cb726ae92dca3"
-  integrity sha512-fAfeUM5S5qZRjKhfDXQhstLZkAglY0Ka0TXITTFtz0O5o3QQFoJP6PbMPFcw2JZBHLY4JyTVJaPgyVccgwZaGw==
+"@mitodl/course-search-utils@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.0.5.tgz#e57cd667e716b29c337508b3e54f2c67ce29f592"
+  integrity sha512-hIAPnNHicMz39mgjxEpMejh2HNeRyVaXXZpYwY9KonGeoos+Er8hoV5szOE/KNdN9NdmFN/UXVwY+v9jHjLG+w==
   dependencies:
     query-string "^6.13.1"
     ramda "^0.27.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #217 

#### What's this PR do?

This PR adds another FilterableFacet for filtering results based on their department. It works the same as our existing 'Topics' facet.

#### How should this be manually tested?

Try it out and make sure you can change the value selected in the facet, that the search updates as you'd expect, and so on. The values selected should be persisted to the URL under the `d` search param (`d` for department!).

#### Screenshots (if appropriate)

![Screenshot from 2020-10-06 14-53-03](https://user-images.githubusercontent.com/6207644/95247512-f38ce580-07e3-11eb-89ad-2c7c09069cc8.png)
![Screenshot from 2020-10-06 14-52-56](https://user-images.githubusercontent.com/6207644/95247524-f687d600-07e3-11eb-89ba-a4b22eb2c3f5.png)

![Screenshot from 2020-10-06 14-55-12](https://user-images.githubusercontent.com/6207644/95247567-043d5b80-07e4-11eb-802a-649dbd508eb5.png)
