### PR TITLE
put back COURSE_ZIPS_DESTINATION and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,15 @@ These archives can be generated using the following command:
 npm run build:zips
 ```
 
+### env variables
+
+| Variable | Description  | Required? |
+| :------- | :------------ | :------------ |
+| `COURSE_ZIPS_DESTINATION` | The path to output course zips to | No |
+
 This command will run the webpack and pdfjs build once, then iterate the courses found in 
 `/site/content/courses` and run the Hugo build for each of them. Archives are created for 
-each course, and when the whole process is done they are placed in `site/static/zips`.
+each course, and when the whole process is done they are placed in `zips` by default, if `COURSE_ZIPS_DESTINATION` is not set..
 
 ## deployment
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:hugo:debug": "hugo -d ../dist -s site -v --templateMetrics --debug",
     "build:pdfjs": "./build-scripts/build-pdfjs.sh",
     "build:webpack": "cross-env NODE_ENV=production webpack --config src/webpack/webpack.prod.js",
-    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z site/static/zips",
+    "build:zips": "node ./build-scripts/build_course_zips.js -d dist -c site/content/courses -z $COURSE_ZIPS_DESTINATION",
     "import:ocw": "./build-scripts/import_ocw.sh",
     "import:ocw:example_courses": "mkdir -p private/courses && ocw-to-hugo -i private/courses -o site/content -c example_courses.json --download",
     "webpack:stats": "NODE_ENV=production webpack --config src/webpack/webpack.prod.js --profile --json > stats.json",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR fixes a rebase issue that blew away `COURSE_ZIPS_DESTINATION` in the package.json `build:zips` script and also documents the use of the variable in the readme.

#### How should this be manually tested?
ensure that `COURSE_ZIPS_DESTINATION` is properly passed to the script and that the readme changes make sense.