### PR TITLE
Hard code site/content/courses relative to current directory

### DIFF
--- a/build-scripts/build_course_zips.js
+++ b/build-scripts/build_course_zips.js
@@ -23,7 +23,6 @@ const buildZips = async (
   distPath = tmp.dirSync({
     prefix: "dist"
   }).name,
-  coursesPath = "site/content/courses",
   zipsPath = "zips",
   staticAssetsPath,
   staticPrefix
@@ -40,6 +39,7 @@ const buildZips = async (
   }
 
   const baseDir = process.cwd()
+  const coursesPath = path.join(baseDir, "site", "content", "courses")
   const relative = path.relative(baseDir, zipsPath)
   if (
     relative &&
@@ -183,7 +183,6 @@ const buildZips = async (
 if (!module.parent) {
   buildZips(
     process.env["COURSE_ZIPS_DIST_PATH"],
-    process.env["COURSE_ZIPS_COURSES_PATH"],
     process.env["COURSE_ZIPS_DESTINATION"],
     process.env["COURSE_ZIPS_STATIC_ASSET_PATH"],
     process.env["COURSE_ZIPS_STATIC_PREFIX"]

--- a/build-scripts/build_course_zips.test.js
+++ b/build-scripts/build_course_zips.test.js
@@ -1,48 +1,54 @@
 const path = require("path")
-const rimraf = require("rimraf")
-const tmp = require("tmp")
+const fsPromises = require("fs").promises
 
 const { buildZips } = require("./build_course_zips")
 
 describe("build_course_zips", () => {
   const cwd = process.cwd()
   const distPath = path.join(cwd, "dist")
-  const coursesPath = path.join(cwd, "site", "content", "courses")
   const zipsError = new Error(
     "zips path must not be within hugo content or static directories"
   )
 
   it("throws an error if the coursesPath does not exist", async () => {
-    const invalidCoursesPath = tmp.dirSync({
-      prefix: "courses"
-    }).name
-    rimraf.sync(invalidCoursesPath)
-    await buildZips(distPath, invalidCoursesPath).catch(err => {
-      expect(err).toEqual(
-        new Error(`Courses path "${invalidCoursesPath}" not found`)
-      )
-    })
+    let currentCwd
+    try {
+      currentCwd = process.cwd()
+      process.chdir("/tmp")
+      await buildZips(distPath).catch(err => {
+        expect(err).toEqual(
+          new Error(`Courses path "/tmp/site/content/courses" not found`)
+        )
+      })
+    } finally {
+      process.chdir(currentCwd)
+    }
   })
 
   it("throws an error if you pass it an empty courses directory", async () => {
-    const invalidCoursesPath = tmp.dirSync({
-      prefix: "courses"
-    }).name
-    await buildZips(distPath, invalidCoursesPath).catch(err => {
-      expect(err).toEqual(new Error("No courses found"))
-    })
+    let currentCwd
+    try {
+      currentCwd = process.cwd()
+      process.chdir("/tmp")
+      await fsPromises.mkdir("/tmp/site/content/courses", { recursive: true })
+      await buildZips(distPath).catch(err => {
+        expect(err).toEqual(new Error("No courses found"))
+      })
+    } finally {
+      process.chdir(currentCwd)
+    }
   })
 
   it("throws an error when called with content dir as zip destination", async () => {
     const invalidZipsPath = path.join(cwd, "site", "content")
-    await buildZips(distPath, coursesPath, invalidZipsPath).catch(err => {
+    await buildZips(distPath, invalidZipsPath).catch(err => {
       expect(err).toEqual(zipsError)
     })
   })
 
   it("throws an error when called with static dir as zip destination", async () => {
     const invalidZipsPath = path.join(cwd, "site", "static")
-    await buildZips(distPath, coursesPath, invalidZipsPath).catch(err => {
+    await buildZips(distPath, invalidZipsPath).catch(err => {
       expect(err).toEqual(zipsError)
     })
   })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/pull/257#discussion_r504021505

#### What's this PR do?
Removes courses environment. Instead, courses will always be `site/content/courses` which is currently the default value.

#### How should this be manually tested?
Run `npm run build:zips` and verify that the output looks good
