### PR TITLE
Handle bad course results with no runs

### DIFF
--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -47,16 +47,16 @@ const CoverImage = ({ object }) => (
 )
 
 export default function SearchResult(props) {
-  const { searchResultLayout } = props
+  const { searchResultLayout, object } = props
 
-  return (
+  return object.url ? (
     <Card
       className={getClassName(searchResultLayout)}
       borderless={searchResultLayout === SEARCH_GRID_UI}
     >
       <LearningResourceDisplay {...props} />
     </Card>
-  )
+  ) : null
 }
 
 export function LearningResourceDisplay(props) {

--- a/src/js/components/SearchResult.test.js
+++ b/src/js/components/SearchResult.test.js
@@ -90,6 +90,18 @@ describe("SearchResult component", () => {
   })
 
   //
+  ;[(LR_TYPE_RESOURCEFILE, LR_TYPE_COURSE)].forEach(objectType => {
+    it("should not render a course/resource with no url", () => {
+      const object = searchResultToLearningResource(
+        makeLearningResourceResult(objectType)
+      )
+      object.url = null
+      const wrapper = render(object)
+      expect(wrapper.find("Card").exists()).toBeFalsy()
+    })
+  })
+
+  //
   ;[[], null].forEach(listValue => {
     it(`should not render div for instructors, topics if they equal ${String(
       listValue

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -407,7 +407,8 @@ export const getCoverImageUrl = result => {
   }
 }
 
-export const getCourseUrl = result => `/courses/${result.runs[0].slug}/`
+export const getCourseUrl = result =>
+  !emptyOrNil(result.runs) ? `/courses/${result.runs[0].slug}/` : null
 
 export const getResourceUrl = result => {
   if (result.content_type === CONTENT_TYPE_PAGE) {

--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -199,4 +199,14 @@ describe("search library", () => {
       expect(getResultUrl(result)).toBe(expected)
     })
   })
+
+  it(`should return a null url for a course without runs`, () => {
+    const result = makeLearningResourceResult("course")
+    result.runs = []
+    expect(getResultUrl(result)).toBe(null)
+    result.runs = null
+    expect(getResultUrl(result)).toBe(null)
+    delete result.runs
+    expect(getResultUrl(result)).toBe(null)
+  })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #259 

#### What's this PR do?
- Handles course search results with no runs without blowing up the page

#### How should this be manually tested?
- Tests should pass
- Delete all the runs from a published OCW course in open, update in ES, then search for it here by title.  It should show up in the raw search results response but be excluded from results.


