### PR TITLE
add buttons to show currently applied facets, allow for clearing them

### DIFF
--- a/src/css/button.scss
+++ b/src/css/button.scss
@@ -28,7 +28,7 @@ button.blue-btn.outlined {
   }
 
   &:disabled {
-    border-color: $medium-grey;
-    color: $medium-grey;
+    border-color: $medium-gray;
+    color: $medium-gray;
   }
 }

--- a/src/css/search-filter.scss
+++ b/src/css/search-filter.scss
@@ -129,3 +129,38 @@
     text-align: right;
   }
 }
+
+.active-search-filters {
+  border-bottom: 1px solid $font-gray-mid;
+  padding-bottom: 10px;
+  margin-bottom: 10px;
+
+  .clear-all-filters {
+    font-size: 14px;
+    color: $search-gray;
+    font-weight: normal;
+  }
+
+  .active-search-filter {
+    margin: 0px 5px 9px 0px;
+    background-color: $bg-light-gray;
+    padding: 6px 10px;
+    font-size: 14px;
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    border: 1px solid $font-gray-mid;
+    border-radius: 14px;
+
+    .remove-filter {
+      max-height: 18px;
+      margin-right: 5px;
+      cursor: pointer;
+
+      i {
+        font-size: 18px;
+      }
+    }
+  }
+}

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -20,7 +20,7 @@ $font-gray-mid: #8a8b8c;
 $card-background: #fff;
 $font-gray: #888;
 $podcast-border-gray: #9c9d9e;
-$medium-grey: #c2c0bf;
+$medium-gray: #c2c0bf;
 $course-blue: #126f9a;
 
 // full-color design
@@ -40,3 +40,4 @@ $text-box-background: #fbfbfb;
 $search-bg-gray: #f7f7f7;
 $search-gray: rgba(0, 0, 0, 0.85);
 $featured-facet-blue: #385d70;
+$bg-light-gray: #f5f5f5;

--- a/src/js/components/FacetDisplay.js
+++ b/src/js/components/FacetDisplay.js
@@ -1,22 +1,76 @@
 import React from "react"
+import _ from "lodash"
 
 import FilterableFacet from "./FilterableFacet"
+import SearchFilter from "./SearchFilter"
 
-export default function FacetDisplay(props) {
-  const { facetMap, facetOptions, activeFacets, onUpdateFacets } = props
+const FacetDisplay = React.memo(
+  function FacetDisplay(props) {
+    const {
+      facetMap,
+      facetOptions,
+      activeFacets,
+      onUpdateFacets,
+      clearAllFilters,
+      toggleFacet
+    } = props
 
-  return (
-    <React.Fragment>
-      {facetMap.map(([name, title], key) => (
-        <FilterableFacet
-          key={key}
-          results={facetOptions(name)}
-          name={name}
-          title={title}
-          currentlySelected={activeFacets[name] || []}
-          onUpdate={onUpdateFacets}
-        />
-      ))}
-    </React.Fragment>
-  )
-}
+    const anyFiltersActive =
+      _.flatten(_.toArray(Object.values(activeFacets))).length > 0
+
+    return (
+      <React.Fragment>
+        {anyFiltersActive ? (
+          <div className="active-search-filters">
+            <div className="filter-section-title">
+              Filters
+              <span
+                className="clear-all-filters"
+                onClick={clearAllFilters}
+                onKeyPress={e => {
+                  if (e.key === "Enter") {
+                    clearAllFilters()
+                  }
+                }}
+                tabIndex="0"
+              >
+                Clear All
+              </span>
+            </div>
+            {facetMap.map(([name, , labelFunction]) =>
+              (activeFacets[name] || []).map((facet, i) => (
+                <SearchFilter
+                  key={i}
+                  value={facet}
+                  clearFacet={() => toggleFacet(name, facet, false)}
+                  labelFunction={labelFunction}
+                />
+              ))
+            )}
+          </div>
+        ) : null}
+        {facetMap.map(([name, title], key) => (
+          <FilterableFacet
+            key={key}
+            results={facetOptions(name)}
+            name={name}
+            title={title}
+            currentlySelected={activeFacets[name] || []}
+            onUpdate={onUpdateFacets}
+          />
+        ))}
+      </React.Fragment>
+    )
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.activeFacets === nextProps.activeFacets &&
+      prevProps.clearAllFilters === nextProps.clearAllFilters &&
+      prevProps.toggleFacet === nextProps.toggleFacet &&
+      prevProps.facetOptions === nextProps.facetOptions &&
+      prevProps.onUpdateFacets === nextProps.onUpdateFacets
+    )
+  }
+)
+
+export default FacetDisplay

--- a/src/js/components/FacetDisplay.test.js
+++ b/src/js/components/FacetDisplay.test.js
@@ -4,28 +4,63 @@ import { shallow } from "enzyme"
 import FacetDisplay from "./FacetDisplay"
 
 describe("FacetDisplay component", () => {
-  const render = (props = {}) => shallow(<FacetDisplay {...props} />)
+  let activeFacets, facetOptions, onUpdateFacets, clearAllFilters
+
+  const render = (props = {}) =>
+    shallow(
+      <FacetDisplay
+        facetMap={facetMap}
+        facetOptions={facetOptions}
+        activeFacets={activeFacets}
+        onUpdateFacets={onUpdateFacets}
+        clearAllFilters={clearAllFilters}
+        {...props}
+      />
+    )
+
+  const facetMap = [
+    ["topics", "Topics"],
+    ["types", "Types"],
+    ["departments", "Departments"]
+  ]
+
+  beforeEach(() => {
+    activeFacets = {}
+    facetOptions = jest.fn()
+    onUpdateFacets = jest.fn()
+    clearAllFilters = jest.fn()
+  })
 
   test("renders a FacetDisplay with expected FilterableFacets", async () => {
-    const facetMap = [
-      ["topics", "Topics"],
-      ["types", "Types"],
-      ["departments", "Departments"]
-    ]
-    const activeFacets = []
-    const facetOptions = jest.fn()
-    const onUpdateFacets = jest.fn()
-    const wrapper = render({
-      facetMap,
-      facetOptions,
-      activeFacets,
-      onUpdateFacets
-    })
+    const wrapper = render()
     const facets = wrapper.children()
     expect(facets).toHaveLength(3)
     facets.map((facet, key) => {
       expect(facet.prop("name")).toBe(facetMap[key][0])
       expect(facet.prop("title")).toBe(facetMap[key][1])
     })
+  })
+
+  test("shows filters which are active", () => {
+    activeFacets = {
+      topics:      ["Pasta", "Bread", "Starch"],
+      types:       [],
+      departments: ["World Grains and Cereals"]
+    }
+
+    const wrapper = render({
+      facetMap,
+      facetOptions,
+      activeFacets,
+      onUpdateFacets
+    })
+    expect(
+      wrapper
+        .find(".active-search-filters")
+        .find("SearchFilter")
+        .map(el => el.prop("value"))
+    ).toEqual(["Pasta", "Bread", "Starch", "World Grains and Cereals"])
+    wrapper.find(".clear-all-filters").simulate("click")
+    expect(clearAllFilters).toHaveBeenCalled()
   })
 })

--- a/src/js/components/SearchFilter.js
+++ b/src/js/components/SearchFilter.js
@@ -1,0 +1,23 @@
+import React from "react"
+
+export default function SearchFilter(props) {
+  const { value, clearFacet, labelFunction } = props
+
+  return (
+    <div className="active-search-filter">
+      <div
+        className="remove-filter"
+        onClick={clearFacet}
+        onKeyPress={e => {
+          if (e.key === "Enter") {
+            clearFacet()
+          }
+        }}
+        tabIndex="0"
+      >
+        <i className="material-icons">close</i>
+      </div>
+      <div>{labelFunction ? labelFunction(value) : value}</div>
+    </div>
+  )
+}

--- a/src/js/components/SearchFilter.test.js
+++ b/src/js/components/SearchFilter.test.js
@@ -1,0 +1,32 @@
+import React from "react"
+import _ from "lodash"
+import { shallow } from "enzyme"
+
+import SearchFilter from "./SearchFilter"
+
+describe("SearchFilter", () => {
+  let onClickStub
+
+  const renderSearchFilter = props =>
+    shallow(<SearchFilter clearFacet={onClickStub} {...props} />)
+
+  beforeEach(() => {
+    onClickStub = jest.fn()
+  })
+
+  it("should render a search filter correctly", () => {
+    const value = "Upcoming"
+    const wrapper = renderSearchFilter({
+      value,
+      labelFunction: _.upperCase
+    })
+    const label = wrapper.text()
+    expect(label.includes(_.upperCase(value))).toBeTruthy()
+  })
+
+  it("should trigger clearFacet function on click", async () => {
+    const wrapper = renderSearchFilter({ value: "ocw" })
+    wrapper.find(".remove-filter").simulate("click")
+    expect(onClickStub).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/js/components/SearchFilterDrawer.test.js
+++ b/src/js/components/SearchFilterDrawer.test.js
@@ -2,6 +2,7 @@ import React from "react"
 import { shallow } from "enzyme"
 
 import SearchFilterDrawer from "./SearchFilterDrawer"
+import FacetDisplay from "./FacetDisplay"
 
 describe("SearchFilterDrawer component", () => {
   const render = (props = {}) => shallow(<SearchFilterDrawer {...props} />)
@@ -11,7 +12,7 @@ describe("SearchFilterDrawer component", () => {
   test("desktop mode renders a FacetDisplay", async () => {
     getViewportWidthMock.mockImplementation(() => 1000)
     const wrapper = render()
-    expect(wrapper.find("FacetDisplay").exists()).toBeTruthy()
+    expect(wrapper.find(FacetDisplay).exists()).toBeTruthy()
   })
 
   test("phone mode renders a filter control", async () => {
@@ -23,7 +24,7 @@ describe("SearchFilterDrawer component", () => {
     filterControl.simulate("click", mockEvent)
     wrapper.update()
     expect(wrapper.find(".search-filter-drawer-open").exists()).toBeTruthy()
-    expect(wrapper.find("FacetDisplay").exists()).toBeTruthy()
+    expect(wrapper.find(FacetDisplay).exists()).toBeTruthy()
     wrapper.find(".blue-btn").simulate("click", mockEvent)
     wrapper.update()
     expect(wrapper.find(".search-filter-drawer-open").exists()).toBeFalsy()

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -80,7 +80,9 @@ export default function SearchPage() {
     activeFacets,
     onSubmit,
     from,
-    toggleFacets
+    toggleFacets,
+    toggleFacet,
+    clearAllFilters
   } = useCourseSearch(
     runSearch,
     clearSearch,
@@ -149,6 +151,8 @@ export default function SearchPage() {
               facetOptions={facetOptions}
               activeFacets={activeFacets}
               onUpdateFacets={onUpdateFacets}
+              clearAllFilters={clearAllFilters}
+              toggleFacet={toggleFacet}
             />
           )}
           <div className="search-results col-12 col-lg-8 col-xl-8 mt-3 mx-auto px-0">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #256

#### What's this PR do?

this adds little buttons to show the filters that you currently have enabled and allow the user to remove them one by one or remove all of them. it's very similar to what we have on the course search on Open.

#### How should this be manually tested?

Go check out the search. When you click one of the facet options you should see a little thingy (shown below) show up that you can then click to remove it. the '

#### Screenshots (if appropriate)

![Screenshot from 2020-10-14 18-31-14](https://user-images.githubusercontent.com/6207644/96052444-9203f100-0e4b-11eb-8cb7-87a4930d9052.png)
