### PR TITLE
Add course cards to home page

### DIFF
--- a/site/layouts/partials/topics_summary.html
+++ b/site/layouts/partials/topics_summary.html
@@ -8,4 +8,4 @@
         {{- end -}}
     {{- end -}}
 {{- end -}}
-{{- delimit $topicsList "&nbsp;&nbsp;" -}}
+{{- delimit $topicsList ", " -}}

--- a/site/layouts/partials/topics_summary.html
+++ b/site/layouts/partials/topics_summary.html
@@ -1,0 +1,11 @@
+{{- $topicsList := slice -}}
+{{- range $topic, $subtopics := . -}}
+    {{- if not $subtopics -}}
+        {{- $topicsList = $topicsList | append (title $topic) -}}
+    {{- else -}}
+        {{- range $subtopic, $specialities := $subtopics -}}
+        {{- $topicsList = $topicsList | append (title $subtopic) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- delimit $topicsList "&nbsp;&nbsp;" -}}

--- a/site/layouts/partials/topics_summary.html
+++ b/site/layouts/partials/topics_summary.html
@@ -8,4 +8,4 @@
         {{- end -}}
     {{- end -}}
 {{- end -}}
-{{- delimit $topicsList ", " -}}
+{{- delimit (first 3 (uniq $topicsList)) ", " -}}

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -13,7 +13,7 @@
       <div class="row">
         {{ range first 4 $childPages }}
           {{ $info := .Params.course_info }}
-          <div class="col-lg-3 col-md-6 col-sm-12 my-1">
+          <div class="col-xl-3 col-lg-6 col-md-6 col-sm-12 my-1 d-flex justify-content-center">
             <div class="course-card">
               <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
               <div class="course-card-content p-3">

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -13,7 +13,7 @@
       <div class="row">
         {{ range first 4 $childPages }}
           {{ $info := .Params.course_info }}
-        <div class="col">
+        <div class="col-lg-3 col-md-6 col-sm-12">
           <div class="course-card">
             <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
             <div class="course-card-content">

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -13,27 +13,27 @@
       <div class="row">
         {{ range first 4 $childPages }}
           {{ $info := .Params.course_info }}
-        <div class="col-lg-3 col-md-6 col-sm-12">
-          <div class="course-card mt-1 mb-1">
-            <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
-            <div class="course-card-content p-3">
-              <div class="course-level">
-                {{ index $info.course_numbers 0 }} | {{ $info.level }}
-              </div>
-              <div class="pt-3">
-                <h5>
-                  <a href="{{ .Permalink}}">{{ .Params.course_title }}</a>
-                </h5>
-              </div>
-              <div class="pt-3">
-                <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
-              </div>
-              <div class="pt-2">
-                <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
+          <div class="col-lg-3 col-md-6 col-sm-12">
+            <div class="course-card mt-1 mb-1">
+              <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
+              <div class="course-card-content p-3">
+                <div class="course-level">
+                  {{ index $info.course_numbers 0 }} | {{ $info.level }}
+                </div>
+                <div class="pt-3">
+                  <h5>
+                    <a href="{{ .Permalink}}">{{ .Params.course_title }}</a>
+                  </h5>
+                </div>
+                <div class="pt-3">
+                  <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
+                </div>
+                <div class="pt-2">
+                  <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
+                </div>
               </div>
             </div>
           </div>
-        </div>
         {{ end }}
       </div>
     </div>

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -29,7 +29,7 @@
                 <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
               </div>
               <div class="card-line">
-                <span class="card-label">Topic(s):</span> {{ delimit $info.topicslist "&nbsp;&nbsp;" }}
+                <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
               </div>
             </div>
           </div>

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -7,7 +7,7 @@
   <div class="new-courses d-flex flex-column align-items-center">
     {{ $pages := .Site.Pages.ByPublishDate.Reverse }}
     {{ $coursePages := where $pages "Type" "==" "course" }}
-    {{ $childPages := where $coursePages ".Parent.Type" "==" "courseindex" }}
+    {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
     <div class="course-cards container mt-3">
       <h3>NEW COURSES</h3>
       <div class="row">

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -8,27 +8,27 @@
     {{ $pages := .Site.Pages.ByPublishDate.Reverse }}
     {{ $coursePages := where $pages "Type" "==" "course" }}
     {{ $childPages := where $coursePages ".Parent.Type" "==" "courseindex" }}
-    <div class="course-cards container">
+    <div class="course-cards container mt-3">
       <h3>NEW COURSES</h3>
       <div class="row">
         {{ range first 4 $childPages }}
           {{ $info := .Params.course_info }}
         <div class="col-lg-3 col-md-6 col-sm-12">
-          <div class="course-card">
+          <div class="course-card mt-1 mb-1">
             <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
-            <div class="course-card-content">
+            <div class="course-card-content p-3">
               <div class="course-level">
                 {{ index $info.course_numbers 0 }} | {{ $info.level }}
               </div>
-              <div class="card-line">
+              <div class="pt-3">
                 <h5>
                   <a href="{{ .Permalink}}">{{ .Params.course_title }}</a>
                 </h5>
               </div>
-              <div class="card-line">
+              <div class="pt-3">
                 <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
               </div>
-              <div class="card-line">
+              <div class="pt-2">
                 <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
               </div>
             </div>

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -13,8 +13,8 @@
       <div class="row">
         {{ range first 4 $childPages }}
           {{ $info := .Params.course_info }}
-          <div class="col-lg-3 col-md-6 col-sm-12">
-            <div class="course-card mt-1 mb-1">
+          <div class="col-lg-3 col-md-6 col-sm-12 my-1">
+            <div class="course-card">
               <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
               <div class="course-card-content p-3">
                 <div class="course-level">
@@ -26,7 +26,7 @@
                   </h5>
                 </div>
                 <div class="pt-3">
-                  <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
+                  <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $info.instructors)) ", " }}
                 </div>
                 <div class="pt-2">
                   <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -4,11 +4,45 @@
     <div id="home-search-box" class="w-100">
     </div>
   </div>
+  <div class="new-courses d-flex flex-column align-items-center">
+    {{ $pages := .Site.Pages.ByPublishDate.Reverse }}
+    {{ $coursePages := where $pages "Type" "==" "course" }}
+    {{ $childPages := where $coursePages ".Parent.Type" "==" "courseindex" }}
+    <div class="course-cards container">
+      <h3>NEW COURSES</h3>
+      <div class="row">
+        {{ range first 4 $childPages }}
+          {{ $info := .Params.course_info }}
+        <div class="col">
+          <div class="course-card">
+            <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
+            <div class="course-card-content">
+              <div class="course-level">
+                {{ index $info.course_numbers 0 }} | {{ $info.level }}
+              </div>
+              <div class="card-line">
+                <h5>
+                  <a href="{{ .Permalink}}">{{ .Params.course_title }}</a>
+                </h5>
+              </div>
+              <div class="card-line">
+                <span class="card-label">Instructors(s):</span> {{ delimit $info.instructors ", " }}
+              </div>
+              <div class="card-line">
+                <span class="card-label">Topic(s):</span> {{ delimit $info.topicslist "&nbsp;&nbsp;" }}
+              </div>
+            </div>
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </div>
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>
-      As we approach the 20th anniversary of MIT OpenCourseWare, we are redesigning our platform and user experience. 
-      This site is the first instantiation of this redesign and is being used to collect feedback from users (like you). 
+      As we approach the 20th anniversary of MIT OpenCourseWare, we are redesigning our platform and user experience.
+      This site is the first instantiation of this redesign and is being used to collect feedback from users (like you).
       We are currently focusing on the following features (each with varying levels of completeness). Be sure to checkout the following features:
     </p>
     <ul>

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,12 +138,22 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
+  max-width: 1400px;
+
   .course-card {
     display: block;
     border: 1px solid $border-gray;
     border-radius: 7px;
-    width: 100%;
     height: 100%;
+    @include media-breakpoint-down(lg) {
+      width: 350px;
+    }
+    @include media-breakpoint-down(sm) {
+      width: 373px;
+    }
+    @include media-breakpoint-up(xl) {
+      width: 300px;
+    }
 
     a {
       text-decoration: none;

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -143,6 +143,7 @@ $spacer8: map-get($spacers, 8);
     border: 1px solid $border-gray;
     border-radius: 7px;
     min-height: 300px; // TODO: height or min-height?
+    width: 100%;
 
     a {
       text-decoration: none;

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,7 +138,7 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
-  max-width: 1400px;
+  max-width: 1440px;
 
   .course-card {
     display: block;

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -136,3 +136,46 @@ $spacer8: map-get($spacers, 8);
   width: 40px;
   height: 40px;
 }
+
+.course-cards {
+  margin-top: 20px;
+
+  .course-card {
+    display: block;
+    border: 1px solid $border-gray;
+    border-radius: 7px;
+    min-height: 300px; // TODO: height or min-height?
+
+    a {
+      text-decoration: none;
+    }
+
+    h5 {
+      font-size: 16px;
+    }
+
+    img {
+      width: 100%;
+      object-fit: cover;
+      height: 141px;
+    }
+
+    .course-level {
+      text-transform: uppercase;
+      color: $font-gray-mid;
+    }
+
+    .course-card-content {
+      padding: 10px;
+
+      .card-line {
+        font-size: 12px;
+        padding-top: 10px;
+
+        .card-label {
+          color: $give-heart-gray;
+        }
+      }
+    }
+  }
+}

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -145,6 +145,7 @@ $spacer8: map-get($spacers, 8);
     border: 1px solid $border-gray;
     border-radius: 7px;
     min-height: 300px; // TODO: height or min-height?
+    margin-bottom: 10px;
 
     a {
       text-decoration: none;

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,14 +138,11 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
-  margin-top: 20px;
-
   .course-card {
     display: block;
     border: 1px solid $border-gray;
     border-radius: 7px;
     min-height: 300px; // TODO: height or min-height?
-    margin-bottom: 10px;
 
     a {
       text-decoration: none;
@@ -167,15 +164,10 @@ $spacer8: map-get($spacers, 8);
     }
 
     .course-card-content {
-      padding: 10px;
+      font-size: 12px;
 
-      .card-line {
-        font-size: 12px;
-        padding-top: 10px;
-
-        .card-label {
-          color: $give-heart-gray;
-        }
+      .card-label {
+        color: $give-heart-gray;
       }
     }
   }

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -142,8 +142,8 @@ $spacer8: map-get($spacers, 8);
     display: block;
     border: 1px solid $border-gray;
     border-radius: 7px;
-    min-height: 300px; // TODO: height or min-height?
     width: 100%;
+    height: 100%;
 
     a {
       text-decoration: none;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #240 

#### What's this PR do?
Adds four course cards to the home page using data from the course frontmatter

#### How should this be manually tested?
- Use an updated version of ocw-to-hugo to create markdown for the site. It needs to include https://github.com/mitodl/ocw-to-hugo/pull/101 and https://github.com/mitodl/ocw-to-hugo/pull/102
 - View the homepage. You should see up to 4 course cards sorted from most recently published


#### Screenshots
See comment below