### PR TITLE
Clear type-specific facets when switching between resources and courses

### DIFF
--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -137,7 +137,12 @@ describe("SearchPage component", () => {
   })
 
   test("the user can switch to resource search", async () => {
-    const wrapper = await render()
+    const parameters = {
+      text:         "Math 101",
+      activeFacets: { topics: ["mathematics"] }
+    }
+    const searchString = serializeSearchParams(parameters)
+    const wrapper = await render(searchString)
     await act(async () => {
       wrapper
         .find(".search-nav")
@@ -148,15 +153,15 @@ describe("SearchPage component", () => {
     expect(search.mock.calls).toEqual([
       [
         {
-          text:         undefined,
+          text:         parameters.text,
           from:         0,
           size:         SEARCH_PAGE_SIZE,
-          activeFacets: defaultCourseFacets
+          activeFacets: { ...defaultCourseFacets, ...parameters.activeFacets }
         }
       ],
       [
         {
-          text:         undefined,
+          text:         parameters.text,
           from:         0,
           size:         SEARCH_PAGE_SIZE,
           activeFacets: defaultResourceFacets


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #265 

#### What's this PR do?
When switching the search page from courses to resources, clear the department and topic facet choices (but not the text query).  This is written in such a way that if courses and resources share some of the same facets in the future, those shared facet choices will not be cleared when switching.

#### How should this be manually tested?
- Search for courses using a text query and 1 or more department & topic facets.  
- Switch to resource search.  The facets should be cleared but not the text query (look at the URL).
