### PR TITLE
add level facet

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
-    "@mitodl/course-search-utils": "^1.0.6",
+    "@mitodl/course-search-utils": "^1.1.1",
     "@mitodl/ocw-to-hugo": "1.0.11",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -20,7 +20,8 @@ export const SEARCH_PAGE_SIZE = 10
 
 const COURSE_FACETS = [
   ["topics", "Topics"],
-  ["department_name", "Department"]
+  ["department_name", "Department"],
+  ["level", "Level"]
 ]
 
 // TBD

--- a/src/js/components/SearchPage.test.js
+++ b/src/js/components/SearchPage.test.js
@@ -70,14 +70,14 @@ describe("SearchPage component", () => {
 
   //
   ;[
-    { text: undefined, activeFacets: {} },
+    { text: "", activeFacets: {} },
     { text: "amazing text!", activeFacets: {} },
     {
       text:         "great search",
       activeFacets: { topics: ["mathematics"] }
     },
     {
-      text:         undefined,
+      text:         "",
       activeFacets: { topics: ["science"] }
     }
   ].forEach(params => {
@@ -117,7 +117,7 @@ describe("SearchPage component", () => {
     expect(search.mock.calls).toEqual([
       [
         {
-          text:         undefined,
+          text:         "",
           from:         0,
           size:         SEARCH_PAGE_SIZE,
           activeFacets: defaultCourseFacets
@@ -203,7 +203,7 @@ describe("SearchPage component", () => {
     expect(search.mock.calls).toEqual([
       [
         {
-          text:         undefined,
+          text:         "",
           from:         0,
           size:         SEARCH_PAGE_SIZE,
           activeFacets: defaultCourseFacets
@@ -211,7 +211,7 @@ describe("SearchPage component", () => {
       ],
       [
         {
-          text:         undefined,
+          text:         "",
           from:         SEARCH_PAGE_SIZE,
           size:         SEARCH_PAGE_SIZE,
           activeFacets: defaultCourseFacets
@@ -219,7 +219,7 @@ describe("SearchPage component", () => {
       ],
       [
         {
-          text:         undefined,
+          text:         "",
           from:         2 * SEARCH_PAGE_SIZE,
           size:         SEARCH_PAGE_SIZE,
           activeFacets: defaultCourseFacets

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@mitodl/course-search-utils@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.0.6.tgz#5a43d40651ca4345d57c1ae19ee52346b704fbe7"
-  integrity sha512-KvND5VHnBpohcvxLQQ1mFBOvXDygSNXcZJBxyrr0jYXTZGYcVL6zlpvE26+gFlkNEiIPWn+KsP77kqNnN/Z6+w==
+"@mitodl/course-search-utils@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/course-search-utils/-/course-search-utils-1.1.1.tgz#e3d8e59102a27a31edbbb32e78055d9f051a8e8f"
+  integrity sha512-XdpMMuFrZSHunceg6C9b8QjwD/tQOJ0TDKQsTZRzfU8j3ODZT6sPsWBDejMlzXeY/apgs37M+s4Aj460d6JsUQ==
   dependencies:
     query-string "^6.13.1"
     ramda "^0.27.1"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #216 

#### What's this PR do?

This adds support for the 'level' facet, by upgrading course-search-utils and making some changes to the code used to generate the ES query.

#### How should this be manually tested?

You'll need to check out this PR on open: https://github.com/mitodl/open-discussions/pull/3187

then you should be able to use the level facet on the OCW course search. It should work as you'd expect, and shouldn't interact weirdly with the other facets.

#### Screenshots (if appropriate)

![Screenshot from 2020-10-21 10-30-34](https://user-images.githubusercontent.com/6207644/96734500-9e76d500-1388-11eb-80b2-38c9ae9673ab.png)
![Screenshot from 2020-10-21 10-30-14](https://user-images.githubusercontent.com/6207644/96734502-9f0f6b80-1388-11eb-9b98-3f7ce09dcad0.png)

