### PR TITLE
fix search result title width

### DIFF
--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -83,7 +83,7 @@ export function LearningResourceDisplay(props) {
             </i>
           ) : null}
           {object.url ? (
-            <a href={object.url}>
+            <a href={object.url} className="w-100">
               <Dotdotdot clamp={3}>
                 {object.content_title || object.title}
               </Dotdotdot>

--- a/src/js/components/SearchResult.test.js
+++ b/src/js/components/SearchResult.test.js
@@ -25,12 +25,12 @@ describe("SearchResult component", () => {
     )
     const wrapper = render(object)
     expect(wrapper.find(".course-title").text()).toBe(object.title)
-    expect(
-      wrapper
-        .find(".course-title")
-        .find("a")
-        .prop("href")
-    ).toBe(object.url)
+    const { href, className } = wrapper
+      .find(".course-title")
+      .find("a")
+      .props()
+    expect(href).toBe(object.url)
+    expect(className).toBe("w-100")
     expect(
       wrapper
         .find(".subtitles")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #270

#### What's this PR do?

this fixed an issue where the `<a>` tag that points to the course wasn't occupying the full width of the `.course-title` div. this puts the width to 100% to ensure that you can click anywhere in the `.course-title` div and get to the course.

#### How should this be manually tested?

check out the branch, and ensure the behavior described above works!
