### PR TITLE
Add bootstrap carousel for course cards

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -6,6 +6,7 @@
         {{ range $breakpoint, $carouselInfo := $breakdowns }}
             {{ $itemsInCarousel := index $carouselInfo "size" }}
             {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
+            {{ $isMobile := (eq $itemsInCarousel 1) }}
             <div class="{{ $breakpointVisibilityClass }}">
                 <div id="carousel-{{ $breakpoint }}" class="carousel slide">
                     <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
@@ -21,7 +22,7 @@
                             </a>
                         </h4>
                     </div>
-                    <div class="carousel-inner justify-content-center container mt-4">
+                    <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-4">
                         {{ $pagesChunk := (first 10 $pages) }}
                         {{ range $index, $page := $pagesChunk }}
                             {{ with $page }}
@@ -29,9 +30,9 @@
                                 {{ $modulo := (mod $index $itemsInCarousel) }}
                                 {{ $group := (div $index $itemsInCarousel) }}
                                 {{ if eq $modulo 0 }}
-                                    <div class="carousel-item row {{ if eq $group 0 }}active{{ end }}">
+                                    <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
                                 {{ end }}
-                                        <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 col-xl-3 course-card-container d-flex justify-content-center">
+                                        <div class="{{ if not $isMobile }}col-3{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card">
                                                 <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
                                                 <div class="course-card-content p-3">

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,0 +1,65 @@
+<div class="new-courses">
+    <div class="course-cards container mt-3">
+        {{ $pages := . }}
+        {{ $breakdowns := (dict "sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 4 "class" "d-none d-md-flex")) }}
+        <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
+        {{ range $breakpoint, $carouselInfo := $breakdowns }}
+            {{ $itemsInCarousel := index $carouselInfo "size" }}
+            {{ $breakpointVisibilityClass := index $carouselInfo "class" }}
+            <div class="{{ $breakpointVisibilityClass }}">
+                <div id="carousel-{{ $breakpoint }}" class="carousel slide">
+                    <div class="carousel-header d-flex flex-row justify-content-between font-weight-bold text-uppercase">
+                        <h3 class="new-courses-title">New Courses</h3>
+                        <h4 class="d-flex">
+                            <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="prev" class="prev">
+                                <span class="material-icons">keyboard_arrow_left</span>
+                                Previous
+                            </a>
+                            <a href="#carousel-{{ $breakpoint }}" role="button" data-slide="next" class="next">
+                                Next
+                                <span class="material-icons">keyboard_arrow_right</span>
+                            </a>
+                        </h4>
+                    </div>
+                    <div class="carousel-inner justify-content-center container mt-4">
+                        {{ $pagesChunk := (first 10 $pages) }}
+                        {{ range $index, $page := $pagesChunk }}
+                            {{ with $page }}
+                                {{ $info := .Params.course_info }}
+                                {{ $modulo := (mod $index $itemsInCarousel) }}
+                                {{ $group := (div $index $itemsInCarousel) }}
+                                {{ if eq $modulo 0 }}
+                                    <div class="carousel-item row {{ if eq $group 0 }}active{{ end }}">
+                                {{ end }}
+                                        <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 col-xl-3 course-card-container d-flex justify-content-center">
+                                            <div class="course-card">
+                                                <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
+                                                <div class="course-card-content p-3">
+                                                    <div class="course-level">
+                                                        {{ index $info.course_numbers 0 }} | {{ $info.level }}
+                                                    </div>
+                                                    <div class="pt-3">
+                                                        <h5>
+                                                            <a href="{{ .Permalink }}">{{ .Params.course_title }}</a>
+                                                        </h5>
+                                                    </div>
+                                                    <div class="pt-3">
+                                                        <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $info.instructors)) ", " }}
+                                                    </div>
+                                                    <div class="pt-2">
+                                                        <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                {{ if (or (eq $modulo (sub $itemsInCarousel 1)) (eq $index (sub (len $pagesChunk) 1))) }}
+                                    </div>
+                                {{ end }}
+                            {{ end }}
+                        {{ end }}
+                    </div>
+                </div>
+            </div>
+        {{ end }}
+    </div>
+</div>

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,7 +1,7 @@
 <div class="new-courses">
     <div class="course-cards container mt-3 mx-auto w-100">
         {{ $pages := . }}
-        {{ $breakdowns := (dict "xs" (dict "size" 1 "class" "d-flex d-sm-none") "sm-md-lg" (dict "size" 2 "class" "d-none d-sm-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
+        {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md-lg" (dict "size" 2 "class" "d-none d-md-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
         <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
         {{ range $breakpoint, $carouselInfo := $breakdowns }}
             {{ $itemsInCarousel := index $carouselInfo "size" }}

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,7 +1,7 @@
 <div class="new-courses">
     <div class="course-cards container mt-3 mx-auto w-100">
         {{ $pages := . }}
-        {{ $breakdowns := (dict "sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 4 "class" "d-none d-md-flex")) }}
+        {{ $breakdowns := (dict "xs" (dict "size" 1 "class" "d-flex d-sm-none") "sm-md-lg" (dict "size" 2 "class" "d-none d-sm-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
         <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
         {{ range $breakpoint, $carouselInfo := $breakdowns }}
             {{ $itemsInCarousel := index $carouselInfo "size" }}
@@ -32,7 +32,7 @@
                                 {{ if eq $modulo 0 }}
                                     <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
                                 {{ end }}
-                                        <div class="{{ if not $isMobile }}col-3{{ end }} w-100 d-flex justify-content-center">
+                                        <div class="{{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card">
                                                 <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
                                                 <div class="course-card-content p-3">

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,5 +1,5 @@
 <div class="new-courses">
-    <div class="course-cards container mt-3">
+    <div class="course-cards container mt-3 mx-auto w-100">
         {{ $pages := . }}
         {{ $breakdowns := (dict "sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 4 "class" "d-none d-md-flex")) }}
         <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->

--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -4,40 +4,10 @@
     <div id="home-search-box" class="w-100">
     </div>
   </div>
-  <div class="new-courses d-flex flex-column align-items-center">
-    {{ $pages := .Site.Pages.ByPublishDate.Reverse }}
-    {{ $coursePages := where $pages "Type" "==" "course" }}
-    {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
-    <div class="course-cards container mt-3">
-      <h3>NEW COURSES</h3>
-      <div class="row">
-        {{ range first 4 $childPages }}
-          {{ $info := .Params.course_info }}
-          <div class="col-xl-3 col-lg-6 col-md-6 col-sm-12 my-1 d-flex justify-content-center">
-            <div class="course-card">
-              <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}" />
-              <div class="course-card-content p-3">
-                <div class="course-level">
-                  {{ index $info.course_numbers 0 }} | {{ $info.level }}
-                </div>
-                <div class="pt-3">
-                  <h5>
-                    <a href="{{ .Permalink}}">{{ .Params.course_title }}</a>
-                  </h5>
-                </div>
-                <div class="pt-3">
-                  <span class="card-label">Instructors(s):</span> {{ delimit (first 3 (uniq $info.instructors)) ", " }}
-                </div>
-                <div class="pt-2">
-                  <span class="card-label">Topic(s):</span> {{ partial "topics_summary.html" $info.topics }}
-                </div>
-              </div>
-            </div>
-          </div>
-        {{ end }}
-      </div>
-    </div>
-  </div>
+  {{ $pages := .Site.Pages.ByPublishDate.Reverse }}
+  {{ $coursePages := where $pages "Type" "==" "course" }}
+  {{ $childPages := where $coursePages ".Params.layout" "==" "course_home" }}
+  {{ partial "home_course_cards.html" $childPages }}
   <div class="beta-dialog bg-dark-gray px-8 py-4 d-none">
     <h2>Next Generation OpenCourseWare</h2>
     <p>

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,7 +138,7 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
-  $maxwidth: 1280px;
+  $maxwidth: 1200px;
   max-width: $maxwidth;
 
   a {
@@ -149,11 +149,7 @@ $spacer8: map-get($spacers, 8);
     border: 1px solid $border-gray;
     border-radius: 7px;
     height: 400px;
-    width: 300px;
-
-    @include media-breakpoint-down(sm) {
-      width: 373px;
-    }
+    width: 100%;
 
     h5 {
       font-size: 16px;
@@ -187,15 +183,10 @@ $spacer8: map-get($spacers, 8);
   }
 
   .carousel {
-    width: $maxwidth;
-    @include media-breakpoint-down(sm) {
-      width: 100%;
-    }
+    max-width: $maxwidth;
+    width: 100%;
 
     .carousel-inner {
-      @include media-breakpoint-up(md) {
-        width: $maxwidth;
-      }
       max-width: $maxwidth;
     }
 
@@ -203,7 +194,7 @@ $spacer8: map-get($spacers, 8);
       max-width: $maxwidth;
       margin: 0 40px 0 15px;
 
-      @include media-breakpoint-down(sm) {
+      @include media-breakpoint-down(xs) {
         margin: 0;
 
         h3 {
@@ -226,7 +217,7 @@ $spacer8: map-get($spacers, 8);
         align-items: center;
         margin-left: 8px;
         padding: 12px 6px 6px 6px;
-        @include media-breakpoint-down(sm) {
+        @include media-breakpoint-down(xs) {
           &.next {
             padding: 12px 2px 6px 10px;
           }
@@ -239,7 +230,7 @@ $spacer8: map-get($spacers, 8);
         .material-icons {
           // nudge to match rest of line
           top: -4px;
-          @include media-breakpoint-down(sm) {
+          @include media-breakpoint-down(xs) {
             top: -2px;
           }
 

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -188,15 +188,18 @@ $spacer8: map-get($spacers, 8);
 
     .carousel-inner {
       max-width: $maxwidth;
+      width: 100%;
     }
 
     .carousel-header {
       max-width: $maxwidth;
       margin: 0 40px 0 15px;
 
-      @include media-breakpoint-down(xs) {
+      @include media-breakpoint-down(sm) {
         margin: 0;
+      }
 
+      @include media-breakpoint-down(xs) {
         h3 {
           font-size: 14px;
         }

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -216,28 +216,23 @@ $spacer8: map-get($spacers, 8);
       a {
         border: 1px solid $border-dark-color;
         border-radius: 5px;
-        display: inline-flex;
+        display: flex;
         align-items: center;
         margin-left: 8px;
-        padding: 12px 6px 6px 6px;
+        padding: 6px;
+
+        span {
+          display: inline;
+        }
+
         @include media-breakpoint-down(xs) {
           &.next {
-            padding: 12px 2px 6px 10px;
+            padding: 6px 2px 6px 10px;
           }
 
           &.prev {
-            padding: 12px 10px 6px 2px;
+            padding: 6px 10px 6px 2px;
           }
-        }
-
-        .material-icons {
-          // nudge to match rest of line
-          top: -4px;
-          @include media-breakpoint-down(xs) {
-            top: -2px;
-          }
-
-          position: relative;
         }
       }
     }

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,25 +138,22 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
-  max-width: 1440px;
+  $maxwidth: 1280px;
+  max-width: $maxwidth;
+
+  a {
+    text-decoration: none;
+  }
 
   .course-card {
-    display: block;
     border: 1px solid $border-gray;
     border-radius: 7px;
-    height: 100%;
-    @include media-breakpoint-down(lg) {
-      width: 350px;
-    }
-    @include media-breakpoint-down(sm) {
-      width: 373px;
-    }
-    @include media-breakpoint-up(xl) {
-      width: 300px;
-    }
+    height: 400px;
+    width: 300px;
 
-    a {
-      text-decoration: none;
+    @include media-breakpoint-down(sm) {
+      max-width: 373px;
+      width: 100%;
     }
 
     h5 {
@@ -179,6 +176,75 @@ $spacer8: map-get($spacers, 8);
 
       .card-label {
         color: $give-heart-gray;
+      }
+    }
+  }
+
+  .carousel-item.active,
+  .carousel-item-next,
+  .carousel-item-prev {
+    // this is display: block in bootstrap but we want to have cards laid out properly
+    display: flex;
+  }
+
+  .carousel {
+    width: $maxwidth;
+    @include media-breakpoint-down(sm) {
+      width: 100%;
+    }
+
+    .carousel-inner {
+      width: $maxwidth;
+      @include media-breakpoint-down(sm) {
+        width: 100%;
+      }
+      max-width: $maxwidth;
+    }
+
+    .carousel-header {
+      max-width: $maxwidth;
+      margin: 0 40px 0 15px;
+
+      @include media-breakpoint-down(sm) {
+        h3 {
+          font-size: 14px;
+        }
+
+        h4 {
+          font-size: 12px;
+        }
+      }
+
+      .new-courses-title {
+        padding: 12px 0 6px 0;
+      }
+
+      a {
+        border: 1px solid $border-dark-color;
+        border-radius: 5px;
+        display: inline-flex;
+        align-items: center;
+        margin-left: 8px;
+        padding: 12px 6px 6px 6px;
+        @include media-breakpoint-down(sm) {
+          &.next {
+            padding: 12px 2px 6px 10px;
+          }
+
+          &.prev {
+            padding: 12px 10px 6px 2px;
+          }
+        }
+
+        .material-icons {
+          // nudge to match rest of line
+          top: -4px;
+          @include media-breakpoint-down(sm) {
+            top: -2px;
+          }
+
+          position: relative;
+        }
       }
     }
   }

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -152,8 +152,7 @@ $spacer8: map-get($spacers, 8);
     width: 300px;
 
     @include media-breakpoint-down(sm) {
-      max-width: 373px;
-      width: 100%;
+      width: 373px;
     }
 
     h5 {
@@ -194,9 +193,8 @@ $spacer8: map-get($spacers, 8);
     }
 
     .carousel-inner {
-      width: $maxwidth;
-      @include media-breakpoint-down(sm) {
-        width: 100%;
+      @include media-breakpoint-up(md) {
+        width: $maxwidth;
       }
       max-width: $maxwidth;
     }
@@ -206,6 +204,8 @@ $spacer8: map-get($spacers, 8);
       margin: 0 40px 0 15px;
 
       @include media-breakpoint-down(sm) {
+        margin: 0;
+
         h3 {
           font-size: 14px;
         }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #268 

#### What's this PR do?
Implements the bootstrap course carousel for course cards. This is rendered twice, once for desktop and once for mobile, and we use CSS to show one or the other depending on the breakpoint.

#### How should this be manually tested?
View the homepage and resize the browser to see how different breakpoints react

#### Screenshots

Desktop:
![Screenshot_2020-10-23 Hugo Course Publisher(1)](https://user-images.githubusercontent.com/863262/97050869-1e996800-154c-11eb-9172-6167f9f445d5.png)

Tablet width. Note that the user will need to scroll to see all the cards. The carousel is effectively the same as for desktop.
![Screenshot_2020-10-23 Hugo Course Publisher(2)](https://user-images.githubusercontent.com/863262/97050909-34a72880-154c-11eb-844a-3573264e7dc0.png)

Wide mobile
![Screenshot_2020-10-23 Hugo Course Publisher(3)](https://user-images.githubusercontent.com/863262/97050948-44bf0800-154c-11eb-9898-8ff0a1e1e489.png)

Narrow mobile
![Screenshot_2020-10-23 Hugo Course Publisher(4)](https://user-images.githubusercontent.com/863262/97050958-4983bc00-154c-11eb-8c8c-4c1145b8fe7a.png)
