### PR TITLE
link from course info to search

### DIFF
--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -13,9 +13,7 @@
     <tr>
       <td class="pl-0">Department</td>
       <td>
-        <a href="#" class="coming-soon">
-          {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.departments "id" "departments") }}
-        </a>
+        {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.departments "id" "departments" "klass" "course-info-department") }}
       </td>
     </tr>
     <tr>
@@ -32,7 +30,11 @@
     </tr>
     <tr>
       <td class="pl-0 pb-3">Level</td>
-      <td>{{ $courseInfo.level }}</td>
+      <td>
+        <a href="#" class="course-info-level">
+          {{ $courseInfo.level }}
+        </a>
+      </td>
     </tr>
   </table>
   <div class="border-bottom-light mb-2">

--- a/site/layouts/partials/partial_collapse_list.html
+++ b/site/layouts/partials/partial_collapse_list.html
@@ -1,3 +1,4 @@
+{{ $className := .klass | default "coming-soon" }}
 {{ if gt (len .list) 4 }}
 <div class="position-relative pr-3">
   <a class="partial-collapse-toggle-link" href="#partial-collapse-container_{{ .id }}" data-toggle="collapse"
@@ -12,7 +13,7 @@
     <ul class="list-unstyled m-0">
       {{ range $item := .list }}
       <li>
-        <a href="#" class="partial-collapse-link coming-soon">
+        <a href="#" class="partial-collapse-link {{ $className }}">
           {{ $item }}
         </a>
       </li>
@@ -25,7 +26,7 @@
 <ul class="list-unstyled m-0">
   {{ range $item := .list }}
   <li>
-    <a href="#" class="coming-soon">
+    <a href="#" class="{{ $className }}">
       {{ $item }}
     </a>
   </li>

--- a/site/layouts/partials/topic.html
+++ b/site/layouts/partials/topic.html
@@ -12,7 +12,7 @@
   </a>
   {{ end }}
   <span class="topic-text-wrapper">
-    <a class="link-unstyled text-dark font-weight-bold coming-soon" href="#">
+    <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
     {{ title .topic }}
     </a>
   </span>
@@ -33,7 +33,7 @@
     </a>
     {{ end }}
     <span class="topic-text-wrapper">
-      <a class="link-unstyled text-dark font-weight-bold coming-soon" href="#">
+      <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
       {{ title $subtopic }}
       </a>
     </span>
@@ -41,7 +41,7 @@
   {{ range $specialities }}
   <div class="pt-1 pb-1 pl-5 collapse{{if eq $index 0 }} show{{ end }}" id="speciality-container_{{ $index }}_{{ $subtopicIndex }}">
     <span class="topic-text-wrapper">
-      <a class="link-unstyled text-dark font-weight-bold coming-soon" href="#">
+      <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
       {{ . }}
       </a>
     </span>

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import SearchPage from "./js/components/SearchPage"
 import { initTheme } from "./js/stylesheets"
 import { initPdfViewers } from "./js/pdf_viewer"
 import { initSentry } from "./js/sentry"
+import { rewriteCourseInfoLinks } from "./js/course_info_links"
 
 window.jQuery = $
 window.$ = $
@@ -51,4 +52,5 @@ $(document).ready(() => {
   initTheme()
   initPdfViewers()
   initSentry()
+  rewriteCourseInfoLinks()
 })

--- a/src/js/course_info_links.js
+++ b/src/js/course_info_links.js
@@ -1,0 +1,23 @@
+import { serializeSearchParams } from "@mitodl/course-search-utils/dist/url_utils"
+import { SEARCH_URL } from "./lib/constants"
+
+const INFO_LINK_MANIFEST = [
+  // see https://github.com/mitodl/hugo-course-publisher/pull/281#issuecomment-719547924
+  // [".course-info-topic", "topics"],
+  [".course-info-level", "level"],
+  [".course-info-department", "department_name"]
+]
+
+export const rewriteCourseInfoLinks = () => {
+  INFO_LINK_MANIFEST.forEach(([className, searchParam]) => {
+    document.querySelectorAll(className).forEach(el => {
+      const value = el.textContent.trim()
+      const url = `${SEARCH_URL}?${serializeSearchParams({
+        activeFacets: {
+          [searchParam]: value
+        }
+      })}`
+      el.setAttribute("href", url)
+    })
+  })
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

#273

#### What's this PR do?

this re-writes the `href` of the links in the course info side panel to link to the search with the relevant parameter and value pre-selected. so if you click for instance 'Undergraduate' in the panel you'll go to `/search/?l=Undergraduate`.

The rewriting happens in JS because I figured that was DRYer.

In this PR I'm addressing the level, topic, and department values because those ones don't require extra search work. I'll circle back for the instructor one.

#### How should this be manually tested?

check out a course page and make sure you can click on those three types of values and that it takes you to a relevant search page. other values in the course info panel (like instructor, course no., or 'taught in') should still have the "Coming soon!" behavior when clicked.
