### PR TITLE
add suggestions UI to Search

### DIFF
--- a/src/css/search.scss
+++ b/src/css/search.scss
@@ -61,6 +61,18 @@
     align-items: center;
     font-style: italic;
   }
+
+  .suggestions {
+    justify-content: center;
+    margin: 0;
+    font-style: italic;
+
+    a.suggestion {
+      text-decoration: underline;
+      color: $link-blue;
+      cursor: pointer;
+    }
+  }
 }
 
 .search-toggle {

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -1,5 +1,7 @@
-import { either, isEmpty, isNil } from "ramda"
+import { either, isEmpty, isNil, match } from "ramda"
 
 export const emptyOrNil = either(isEmpty, isNil)
 
 export const getViewportWidth = () => window.innerWidth
+
+export const isDoubleQuoted = text => !emptyOrNil(match(/^".+"$/, text || ""))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #178 

#### What's this PR do?

this adds a basic 'suggestion' UI, along the lines of what we do in Open course search.

#### How should this be manually tested?

Make a typo in the search, like "sceince", "mothemotics", or something similar. you should get a little suggestion for what you mean, and click on it should change to the search text to that suggestion.

#### Screenshots (if appropriate)

![Screenshot from 2020-10-29 14-57-45](https://user-images.githubusercontent.com/6207644/97619914-36169c00-19f7-11eb-8398-78ef959cce97.png)
![Screenshot from 2020-10-29 14-55-33](https://user-images.githubusercontent.com/6207644/97619917-36af3280-19f7-11eb-90b5-85fc7d2fcbae.png)
