### PR TITLE
Tweak course cards to be 300px wide on desktop view

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -1,7 +1,7 @@
 <div class="new-courses">
     <div class="course-cards container mt-3 mx-auto w-100">
         {{ $pages := . }}
-        {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md-lg" (dict "size" 2 "class" "d-none d-md-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
+        {{ $breakdowns := (dict "xs-sm" (dict "size" 1 "class" "d-flex d-md-none") "md" (dict "size" 2 "class" "d-none d-md-flex d-lg-none") "lg" (dict "size" 3 "class" "d-none d-lg-flex d-xl-none") "xl" (dict "size" 4 "class" "d-none d-xl-flex")) }}
         <!-- list adapted from https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements -->
         {{ range $breakpoint, $carouselInfo := $breakdowns }}
             {{ $itemsInCarousel := index $carouselInfo "size" }}

--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -22,7 +22,7 @@
                             </a>
                         </h4>
                     </div>
-                    <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-4">
+                    <div class="carousel-inner d-flex {{ if not $isMobile }}container{{ end }} mt-4 px-0">
                         {{ $pagesChunk := (first 10 $pages) }}
                         {{ range $index, $page := $pagesChunk }}
                             {{ with $page }}
@@ -32,7 +32,7 @@
                                 {{ if eq $modulo 0 }}
                                     <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
                                 {{ end }}
-                                        <div class="{{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
+                                        <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card">
                                                 <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
                                                 <div class="course-card-content p-3">

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -138,39 +138,51 @@ $spacer8: map-get($spacers, 8);
 }
 
 .course-cards {
-  $maxwidth: 1200px;
+  $maxwidth: 1280px;
   max-width: $maxwidth;
 
   a {
     text-decoration: none;
   }
 
-  .course-card {
-    border: 1px solid $border-gray;
-    border-radius: 7px;
-    height: 400px;
-    width: 100%;
+  .course-card-wrapper {
+    padding: 0 10px;
 
-    h5 {
-      font-size: 16px;
+    &:first-child {
+      padding-left: 0;
     }
 
-    img {
+    &:last-child {
+      padding-right: 0;
+    }
+
+    .course-card {
+      border: 1px solid $border-gray;
+      border-radius: 7px;
+      height: 400px;
       width: 100%;
-      object-fit: cover;
-      height: 141px;
-    }
 
-    .course-level {
-      text-transform: uppercase;
-      color: $font-gray-mid;
-    }
+      h5 {
+        font-size: 16px;
+      }
 
-    .course-card-content {
-      font-size: 12px;
+      img {
+        width: 100%;
+        object-fit: cover;
+        height: 141px;
+      }
 
-      .card-label {
-        color: $give-heart-gray;
+      .course-level {
+        text-transform: uppercase;
+        color: $font-gray-mid;
+      }
+
+      .course-card-content {
+        font-size: 12px;
+
+        .card-label {
+          color: $give-heart-gray;
+        }
       }
     }
   }
@@ -189,15 +201,15 @@ $spacer8: map-get($spacers, 8);
     .carousel-inner {
       max-width: $maxwidth;
       width: 100%;
+
+      .carousel-item {
+        margin-left: 0;
+      }
     }
 
     .carousel-header {
       max-width: $maxwidth;
-      margin: 0 40px 0 15px;
-
-      @include media-breakpoint-down(sm) {
-        margin: 0;
-      }
+      margin: 0;
 
       @include media-breakpoint-down(xs) {
         h3 {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #288 

#### What's this PR do?
Tweaks CSS to widen the course cards to 300px on the wide desktop view. However, the xl breakpoint starts at 1200px so we can't show 4 cards at this width, so at this width it is somewhere closer to 270px. Once it goes below 1200px it becomes 2 cards wide. What do you think @abdulkdawson @pdpinch?

#### How should this be manually tested?
View the home page and resize the browser width

#### Screenshots
These are both of the full browser window:

Narrow desktop view:
![Screenshot_2020-10-30 Hugo Course Publisher(2)](https://user-images.githubusercontent.com/863262/97752007-a130a300-1ac9-11eb-8ebd-68a59b800685.png)

Wide desktop view:
![Screenshot_2020-10-30 Hugo Course Publisher(1)](https://user-images.githubusercontent.com/863262/97752027-ab52a180-1ac9-11eb-818a-e2181d393a52.png)
