### PR TITLE
Enable static/hash.txt for CI deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild": "rimraf dist",
     "build": "npm run build:webpack && npm run build:pdfjs && npm run build:hugo && npm run build:githash",
     "build:externalcontent": "npm run build:webpack && npm run build:pdfjs && hugo -d ../dist -s site -v --theme multi_course --contentDir ",
-    "build:netlify": "node ./build-scripts/netlify_import.js && npm run build:webpack && npm run build:pdfjs && npm run build:hugo:netlify",
+    "build:netlify": "node ./build-scripts/netlify_import.js && npm run build:webpack && npm run build:pdfjs && npm run build:hugo:netlify && npm run build:githash",
     "build:preview": "npm run build:webpack && npm run build:pdfjs && npm run build:hugo:preview",
     "build:githash": "mkdir -p dist/static && git rev-parse HEAD > dist/static/hash.txt",
     "build:hugo": "hugo -d ../dist -s site -v",


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Adds a command to create `static/hash.txt` when `npm run build:netlify` is run. This should add `static/hash.txt` to CI deployments similar to how it works for RC and production.

#### How should this be manually tested?
It's probably easiest to merge first, then check CI to verify that `static/hash.txt` was created.