### PR TITLE
Link to the most recent published course run url

### DIFF
--- a/src/js/factories/search.js
+++ b/src/js/factories/search.js
@@ -72,7 +72,8 @@ export const makeRun = () => {
       `${casual.name} ${casual.name}`,
       `${casual.name} ${casual.name}`
     ],
-    prices: [{ mode: "audit", price: casual.integer(1, 1000) }]
+    prices:    [{ mode: "audit", price: casual.integer(1, 1000) }],
+    published: true
   }
 }
 

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -467,8 +467,19 @@ export const getCoverImageUrl = result => {
   }
 }
 
-export const getCourseUrl = result =>
-  !emptyOrNil(result.runs) ? `/courses/${result.runs[0].slug}/` : null
+export const getCourseUrl = result => {
+  if (emptyOrNil(result.runs)) {
+    return null
+  }
+  const publishedRuns = result.runs.filter(run => run.published)
+  return !emptyOrNil(publishedRuns) ?
+    `/courses/${
+      publishedRuns.sort((a, b) =>
+        a.best_start_date < b.best_start_date ? 1 : -1
+      )[0].slug
+    }/` :
+    null
+}
 
 export const getResourceUrl = result => {
   if (result.content_type === CONTENT_TYPE_PAGE) {

--- a/src/js/lib/search.test.js
+++ b/src/js/lib/search.test.js
@@ -289,9 +289,13 @@ describe("search library", () => {
       const result = makeLearningResourceResult(objectType)
       if (!isCourse) {
         result.content_type = CONTENT_TYPE_PAGE
+      } else {
+        result.runs[0].best_start_date = "2001-11-11"
+        result.runs[1].published = false
+        result.runs[2].best_start_date = "2002-01-01"
       }
       const expected = isCourse ?
-        `/courses/${result.runs[0].slug}/` :
+        `/courses/${result.runs[2].slug}/` :
         `/courses/${result.run_slug}/sections/${result.short_url}/`
       expect(getResultUrl(result)).toBe(expected)
     })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #303

#### What's this PR do?
Instead of assuming the first run in a course is the best run to link to, exclude unpublished runs and find the run with the most recent start date.

#### How should this be manually tested?
In open-discussions, import 3 runs for course 18.01 if they aren't already imported:
```python
from course_catalog.api import sync_ocw_courses
sync_ocw_courses(course_prefixes=[
  "PROD/18/18.01/Fall_2003/18-01-single-variable-calculus-fall-2003/",
  "PROD/18/18.01/Fall_2005/18-01-single-variable-calculus-fall-2005/",
  "PROD/18/18.01/Fall_2006/18-01-single-variable-calculus-fall-2006/"
], blocklist=[], force_overwrite=True, upload_to_s3=False)
```

Then search for 18.01 in OCW.  Click the course link in the first result, it should bring you to http://localhost:3000/courses/18-01-single-variable-calculus-fall-2006/

