### PR TITLE
remove links from Course no., "As Taught In" in course info

### DIFF
--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -18,14 +18,12 @@
     </tr>
     <tr>
       <td class="pl-0">Course No.</td>
-      <td>{{ partial "partial_collapse_list.html" (dict "list" $courseInfo.course_numbers "id" "course_numbers") }}</td>
+      <td>{{ partial "partial_collapse_list.html" (dict "list" $courseInfo.course_numbers "id" "course_numbers" "useLinks" false) }}</td>
     </tr>
     <tr>
       <td class="pl-0 text-nowrap">As Taught In</td>
       <td>
-        <a href="#" class="coming-soon">
-          {{ $courseInfo.term }}
-        </a>
+        {{ $courseInfo.term }}
       </td>
     </tr>
     <tr>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -16,9 +16,7 @@
       <td class="px-2 py-2">
         {{- range $index, $course_number := .Params.course_info.course_numbers -}}
         {{- if $index -}},&nbsp;{{- end -}}
-        <a class="px-0" href="#" class="coming-soon">
-          {{- $course_number -}}
-        </a>
+        {{- $course_number -}}
         {{- end -}}
       </td>
     </tr>

--- a/site/layouts/partials/partial_collapse_list.html
+++ b/site/layouts/partials/partial_collapse_list.html
@@ -1,4 +1,5 @@
 {{ $className := .klass | default "coming-soon" }}
+{{ $useLinks := .useLinks | default true }}
 {{ if gt (len .list) 4 }}
 <div class="position-relative pr-3">
   <a class="partial-collapse-toggle-link" href="#partial-collapse-container_{{ .id }}" data-toggle="collapse"
@@ -13,9 +14,13 @@
     <ul class="list-unstyled m-0">
       {{ range $item := .list }}
       <li>
+        {{ if $useLinks }}
         <a href="#" class="partial-collapse-link {{ $className }}">
           {{ $item }}
         </a>
+        {{ else }}
+        {{ $item }}
+        {{end }}
       </li>
       {{ end }}
     </ul>
@@ -26,9 +31,13 @@
 <ul class="list-unstyled m-0">
   {{ range $item := .list }}
   <li>
+    {{ if $useLinks }}
     <a href="#" class="{{ $className }}">
       {{ $item }}
     </a>
+    {{ else }}
+    {{ $item }}
+    {{end }}
   </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #307 

#### What's this PR do?

makes it so that the course number and the 'As taught in' aren't links any longer (this incidentally removes the 'coming soon...' behavior as well)

#### How should this be manually tested?

check out a course page and make sure that both the course number and the 'as taught in' aren't links any longer.

#### Screenshots (if appropriate)

![Screenshot from 2020-11-06 12-00-19](https://user-images.githubusercontent.com/6207644/98393781-c4a6a100-2027-11eb-89da-e358e8f349f8.png)
![Screenshot from 2020-11-06 12-00-12](https://user-images.githubusercontent.com/6207644/98393782-c4a6a100-2027-11eb-9a72-6bef59fb82bd.png)
![Screenshot from 2020-11-06 11-59-59](https://user-images.githubusercontent.com/6207644/98393784-c53f3780-2027-11eb-954d-aff7d125bd47.png)
