### PR TITLE
remove "download course materials" buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ npm run build:hugo:single_course -- 18-06-linear-algebra-spring-2010
 
 ## build course zips
 
-Each course renders a "Download Course Materials" button in the course info section.
-These archives can be generated using the following command:
+Locally browsable offline sites for each course located at `site/content/courses` 
+can be generated using the following command:
 
 ```sh
 npm run build:zips
 ```
+
+The env variables necessary are detailed below.
 
 ### env variables
 

--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -57,10 +57,5 @@
     {{ end }}
     </ul>
   </div>
-  <div class="mt-3">
-    <a href="/zips/{{ .Params.course_id }}.zip">
-      <div class="btn rounded-0 bg-dark text-white w-100 px-5 py-2 coming-soon">Download Course Materials</div>
-    </a>
-  </div>
 </div>
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/310

#### What's this PR do?
This PR removes the "Download Course Materials" buttons from the `course_info.html` partial.  Course zip building functionality remains intact, but the readme has been updated to only convey that the archives are generated and not linked in the site.

#### How should this be manually tested?
Run the site or visit the deploy preview and ensure that you don't see the Download Course Materials buttons.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/98575060-b6a28b80-2286-11eb-822f-c80fe3188c93.png)
![image](https://user-images.githubusercontent.com/12089658/98575151-d46ff080-2286-11eb-8c85-3a8598fa5788.png)

