### PR TITLE
Instructor search links

### DIFF
--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -7,7 +7,7 @@
     <tr>
       <td class="pl-0">Instructor(s)</td>
       <td>
-        {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.instructors "id" "instructors") }}
+        {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.instructors "id" "instructors" "klass" "course-info-instructor") }}
       </td>
     </tr>
     <tr>

--- a/site/layouts/partials/course_instructor_number.html
+++ b/site/layouts/partials/course_instructor_number.html
@@ -5,7 +5,7 @@
       <td class="px-2 py-2">
         {{- range $index, $instructor := .Params.course_info.instructors -}}
         {{- if $index -}},&nbsp;{{- end -}}
-        <a class="px-0" href="#" class="coming-soon pr-1">
+        <a class="px-0 pr-1 course-info-instructor" href="#">
           {{- $instructor -}}
         </a>
         {{- end -}}

--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -113,7 +113,14 @@ export function LearningResourceDisplay(props) {
               htmlClass="listitem"
             >
               {object.instructors.map((instructor, i) => (
-                <a key={i}>{`Prof. ${instructor}`} </a>
+                <a
+                  key={i}
+                  href={`${SEARCH_URL}?${serializeSearchParams({
+                    text: `"${instructor}"`
+                  })}`}
+                >
+                  {`Prof. ${instructor}`}{" "}
+                </a>
               ))}
             </Subtitle>
           </div>

--- a/src/js/course_info_links.js
+++ b/src/js/course_info_links.js
@@ -4,19 +4,26 @@ import { SEARCH_URL } from "./lib/constants"
 const INFO_LINK_MANIFEST = [
   // see https://github.com/mitodl/hugo-course-publisher/pull/281#issuecomment-719547924
   // [".course-info-topic", "topics"],
-  [".course-info-level", "level"],
-  [".course-info-department", "department_name"]
+  [".course-info-level", "level", null],
+  [".course-info-department", "department_name", null],
+  [".course-info-instructor", "q", "Prof."]
 ]
 
 export const rewriteCourseInfoLinks = () => {
-  INFO_LINK_MANIFEST.forEach(([className, searchParam]) => {
+  INFO_LINK_MANIFEST.forEach(([className, searchParam, replaceText]) => {
     document.querySelectorAll(className).forEach(el => {
-      const value = el.textContent.trim()
-      const url = `${SEARCH_URL}?${serializeSearchParams({
-        activeFacets: {
-          [searchParam]: value
-        }
-      })}`
+      const value = el.textContent.replace(replaceText, "").trim()
+      const url = `${SEARCH_URL}?${serializeSearchParams(
+        searchParam === "q" ?
+          {
+            text: `"${value}"`
+          } :
+          {
+            activeFacets: {
+              [searchParam]: value
+            }
+          }
+      )}`
       el.setAttribute("href", url)
     })
   })

--- a/src/js/course_info_links.test.js
+++ b/src/js/course_info_links.test.js
@@ -1,0 +1,26 @@
+import { rewriteCourseInfoLinks } from "./course_info_links"
+
+describe("course_info_links functions", () => {
+  [
+    [
+      ".course-info-instructor",
+      "Prof. Margaret Hamilton",
+      "q=%22Margaret%20Hamilton%22"
+    ],
+    [".course-info-department", "Biology ", "d=Biology"],
+    [".course-info-level", " Graduate", "l=Graduate"]
+  ].forEach(([className, text, linkParam]) => {
+    it("rewriteCourseInfoLinks adds correct url to element", async () => {
+      const itemLink = document.createElement("a")
+      itemLink.setAttribute("class", className.substring(1))
+      itemLink.innerHTML = text
+
+      jest.spyOn(document, "querySelectorAll").mockImplementation(selector => {
+        return selector === className ? [itemLink] : []
+      })
+
+      rewriteCourseInfoLinks()
+      expect(itemLink.getAttribute("href")).toEqual(`/search/?${linkParam}`)
+    })
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #306 

#### What's this PR do?
Adds search links to each professor name in 3 places: course info sidebar, course home page instructor list, and search result cards.

#### How should this be manually tested?
Each instructor name near the top of each course home page, the sidebar for each course page, and in each search result card should link back to the course search page with a parameter of `q="<first_name last_name>"`.  The department and level links should work the same as before.

#### Screenshots (if appropriate)
<img width="695" alt="Screen Shot 2020-11-09 at 1 51 50 PM" src="https://user-images.githubusercontent.com/187676/98583999-3cc4cf00-2293-11eb-9771-4ed3ef0234dd.png">

<img width="827" alt="Screen Shot 2020-11-09 at 1 51 19 PM" src="https://user-images.githubusercontent.com/187676/98584011-41898300-2293-11eb-915f-4a5cd10f1283.png">

