### PR TITLE
Set page titles

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -1,11 +1,11 @@
 baseurl = ""
 languageCode = "en-us"
 languageLang = "en"
-title = "Hugo Course Publisher"
+title = "MIT OpenCourseWare"
 theme = "multi_course"
 relativeURLs = false
 
 # RSS, categories and tags disabled for an easy start
-# See configuration options for more details: 
+# See configuration options for more details:
 # https://gohugo.io/getting-started/configuration/#toml-configuration
 disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]

--- a/site/config_zip.toml
+++ b/site/config_zip.toml
@@ -1,11 +1,11 @@
 baseurl = ""
 languageCode = "en-us"
 languageLang = "en"
-title = "Hugo Course Publisher"
+title = "MIT OpenCourseWare"
 theme = "single_course"
 relativeURLs = true
 
 # RSS, categories and tags disabled for an easy start
-# See configuration options for more details: 
+# See configuration options for more details:
 # https://gohugo.io/getting-started/configuration/#toml-configuration
 disableKinds = ["RSS", "taxonomy", "taxonomyTerm"]

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,3 +1,2 @@
 ---
-title: Hugo Course Publisher
 ---

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>{{ $.Site.Title }}</title>
+    {{ partial "title.html" . }}
     {{ $stylesheet := .Site.Data.webpack.main }}
     {{ if .Site.IsServer }}
       <link href="{{ print "http://localhost:3001" $stylesheet.css  }}" rel="stylesheet">

--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>{{ $.Site.Title }}</title>
+  {{ partial "title.html" . }}
   {{ $stylesheet := .Site.Data.webpack.main }}
   {{ if .Site.IsServer }}
   <link href="{{ print "http://localhost:3001" $stylesheet.css  }}" rel="stylesheet">

--- a/site/layouts/partials/title.html
+++ b/site/layouts/partials/title.html
@@ -1,0 +1,16 @@
+<title>{{- $titleArray := (slice) -}}
+{{- if .Params.Title -}}
+  {{- $titleArray = $titleArray | append .Params.Title -}}
+{{- end -}}
+{{- if .Page.Params.course_title -}}
+  {{- $titleArray = $titleArray | append .Page.Params.course_title -}}
+  {{- if .Page.Params.course_info.departments -}}
+    {{- $titleArray = $titleArray | append (index .Page.Params.course_info.departments 0) -}}
+  {{- end -}}
+{{- end -}}
+{{- $titleArray = $titleArray | append $.Site.Title -}}
+{{- if lt (len $titleArray) 3 -}}
+  {{- $titleArray = $titleArray | append "Free Online Course Materials" -}}
+{{- end -}}
+{{- delimit $titleArray " | " -}}
+</title>

--- a/src/js/components/SearchBox.js
+++ b/src/js/components/SearchBox.js
@@ -6,7 +6,7 @@ export default function SearchBox(props) {
   return (
     <div className="search-box py-3 py-sm-5 py-md-7">
       <div className="search-box-inner col-12 col-lg-8 col-xl-8  mx-auto d-flex flex-column align-items-center">
-        <h1 className="mb-3 mb-sm-5 mb-md-7">Explore Open Course Ware</h1>
+        <h1 className="mb-3 mb-sm-5 mb-md-7">Explore OpenCourseWare</h1>
         <div className="w-100 d-flex flex-column align-items-center search-input-wrapper">
           <span className="align-self-start pb-1 pb-sm-3">SEARCH</span>
           <div className="w-100 position-relative">

--- a/src/js/components/SearchBox.test.js
+++ b/src/js/components/SearchBox.test.js
@@ -8,7 +8,7 @@ describe("SearchBox component", () => {
 
   test("should render basic stuff", () => {
     const wrapper = render()
-    expect(wrapper.find("h1").text()).toBe("Explore Open Course Ware")
+    expect(wrapper.find("h1").text()).toBe("Explore OpenCourseWare")
     expect(wrapper.find("span").text()).toBe("SEARCH")
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #321 
Fixes #255 (unrelated but one line change)

#### What's this PR do?
Updates handling of page titles. Here's the algorithm:
 - All pages will have the site title. There is also "Free Online Course Materials" if there are 3 or fewer items in the title. The home page title: `MIT OpenCourseWare | Free Online Course Materials`
 - If there is a title in the front matter, it will go first. For example, the search page: `Search | MIT OpenCourseWare | Free Online Course Materials`
 - If the page is a course page, it will use the course title, then the department, then the site title. For example: `DNA&#39;s Sister Does All the Work: The Central Roles of RNA in Gene Expression  | Biology | MIT OpenCourseWare`
 - If a page has both course information and a title in the front matter, then the front matter title will go first, then the course title, then the department, and finally `MIT OpenCourseWare`. This needs additional work in ocw-to-hugo to work properly since some pages like the syllabus page do not also include information about the course.


#### How should this be manually tested?
Click around and look at the titles. You should not see "Hugo" anywhere, and they should approximately resemble similar pages on the current site.
