### PR TITLE
split up course_features.html

### DIFF
--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -40,6 +40,8 @@
                 </div>
                 <div class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">
                   {{ partial "chp_partial.html" (dict "partial" "course_info.html" "context" .) }}
+                  {{ partial "chp_partial.html" (dict "partial" "topics.html" "context" .) }}
+                  {{ partial "chp_partial.html" (dict "partial" "course_features.html" "context" .) }}
                 </div>
               </div>
             </div>

--- a/site/layouts/partials/course_features.html
+++ b/site/layouts/partials/course_features.html
@@ -1,0 +1,11 @@
+{{ if isset .Params "course_info" }}
+{{ $courseInfo := .Params.course_info }}
+<div>
+  <h5 class="font-weight-bold">Course Features</h5>
+  <ul class="list-unstyled m-0">
+  {{ range $courseInfo.course_features }}
+    {{ partial "course_feature.html" . }}
+  {{ end }}
+  </ul>
+</div>
+{{ end }}

--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -37,25 +37,5 @@
       </td>
     </tr>
   </table>
-  <div class="border-bottom-light mb-2">
-    <h5 class="font-weight-bold">Topic(s)</h5>
-    <ul class="list-unstyled pb-2 m-0">
-      {{- $.Scratch.Set "topicIndex" 0 -}}
-      {{ range $topic, $subtopics := $courseInfo.topics }}
-      <li>
-        {{ partial "topic.html" (dict "context" $ "index" ($.Scratch.Get "topicIndex") "topic" $topic "subtopics" $subtopics) }}
-      </li>
-      {{- $.Scratch.Add "topicIndex" 1 -}}
-      {{ end }}
-    </ul>
-  </div>
-  <div>
-    <h5 class="font-weight-bold">Course Features</h5>
-    <ul class="list-unstyled m-0">
-    {{ range $courseInfo.course_features }}
-      {{ partial "course_feature.html" . }}
-    {{ end }}
-    </ul>
-  </div>
 </div>
 {{ end }}

--- a/site/layouts/partials/topics.html
+++ b/site/layouts/partials/topics.html
@@ -1,0 +1,15 @@
+{{ if isset .Params "course_info" }}
+{{ $courseInfo := .Params.course_info }}
+<div class="border-bottom-light mb-2">
+  <h5 class="font-weight-bold">Topic(s)</h5>
+  <ul class="list-unstyled pb-2 m-0">
+    {{- $.Scratch.Set "topicIndex" 0 -}}
+    {{ range $topic, $subtopics := $courseInfo.topics }}
+    <li>
+      {{ partial "topic.html" (dict "context" $ "index" ($.Scratch.Get "topicIndex") "topic" $topic "subtopics" $subtopics) }}
+    </li>
+    {{- $.Scratch.Add "topicIndex" 1 -}}
+    {{ end }}
+  </ul>
+</div>
+{{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/312

#### What's this PR do?
This PR splits up the elements in `course_info.html` into 3 separate partials so they can be rearranged based on the new designs.

#### How should this be manually tested?
Spin up the site or visit the deploy preview.  Each Course Info section should render exactly as before.  You should see no difference.
