### PR TITLE
Re-enable topic search

### DIFF
--- a/site/layouts/partials/topic.html
+++ b/site/layouts/partials/topic.html
@@ -3,16 +3,16 @@
 {{ $subtopics := .subtopics }}
 <div class="position-relative pt-1 pb-1{{ if gt (len .subtopics) 0 }} pl-4{{ end }}">
   {{ if gt (len .subtopics) 0 }}
-  <a class="topic-toggle" 
-    href="#subtopic-container_{{ $index }}" 
-    data-toggle="collapse" 
-    aria-controls="subtopic-container_{{ $index }}" 
+  <a class="topic-toggle"
+    href="#subtopic-container_{{ $index }}"
+    data-toggle="collapse"
+    aria-controls="subtopic-container_{{ $index }}"
     aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
     <i class="material-icons"></i>
   </a>
   {{ end }}
   <span class="topic-text-wrapper">
-    <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
+    <a class="link-unstyled text-dark font-weight-bold course-info-topic" href="#">
     {{ title .topic }}
     </a>
   </span>
@@ -24,16 +24,16 @@
   {{- $subtopicIndex := $context.Scratch.Get "subtopicIndex" -}}
   <div class="position-relative pt-1 pb-1 {{ if gt (len $specialities) 0 }} pl-4{{ end }}">
     {{ if gt (len $specialities) 0 }}
-    <a class="topic-toggle" 
-      href="#speciality-container_{{ $index }}_{{ $subtopicIndex }}" 
-      data-toggle="collapse" 
-      aria-controls="speciality-container_{{ $index }}_{{ $subtopicIndex }}" 
+    <a class="topic-toggle"
+      href="#speciality-container_{{ $index }}_{{ $subtopicIndex }}"
+      data-toggle="collapse"
+      aria-controls="speciality-container_{{ $index }}_{{ $subtopicIndex }}"
       aria-expanded="{{ if eq $index 0 }}true{{ else }}false{{ end }}">
       <i class="material-icons"></i>
     </a>
     {{ end }}
     <span class="topic-text-wrapper">
-      <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
+      <a class="link-unstyled text-dark font-weight-bold course-info-topic" href="#">
       {{ title $subtopic }}
       </a>
     </span>
@@ -41,7 +41,7 @@
   {{ range $specialities }}
   <div class="pt-1 pb-1 pl-5 collapse{{if eq $index 0 }} show{{ end }}" id="speciality-container_{{ $index }}_{{ $subtopicIndex }}">
     <span class="topic-text-wrapper">
-      <a class="link-unstyled text-dark font-weight-bold course-info-topic coming-soon" href="#">
+      <a class="link-unstyled text-dark font-weight-bold course-info-topic" href="#">
       {{ . }}
       </a>
     </span>

--- a/src/js/course_info_links.js
+++ b/src/js/course_info_links.js
@@ -3,7 +3,7 @@ import { SEARCH_URL } from "./lib/constants"
 
 const INFO_LINK_MANIFEST = [
   // see https://github.com/mitodl/hugo-course-publisher/pull/281#issuecomment-719547924
-  // [".course-info-topic", "topics"],
+  [".course-info-topic", "topics"],
   [".course-info-level", "level", null],
   [".course-info-department", "department_name", null],
   [".course-info-instructor", "q", "Prof."]

--- a/src/js/course_info_links.test.js
+++ b/src/js/course_info_links.test.js
@@ -8,7 +8,12 @@ describe("course_info_links functions", () => {
       "q=%22Margaret%20Hamilton%22"
     ],
     [".course-info-department", "Biology ", "d=Biology"],
-    [".course-info-level", " Graduate", "l=Graduate"]
+    [".course-info-level", " Graduate", "l=Graduate"],
+    [
+      ".course-info-topic",
+      " Mechanical Engineering",
+      "t=Mechanical%20Engineering"
+    ]
   ].forEach(([className, text, linkParam]) => {
     it("rewriteCourseInfoLinks adds correct url to element", async () => {
       const itemLink = document.createElement("a")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #309 

#### What's this PR do?
Re-enables the topic search links

#### How should this be manually tested?
Click on the topics at each of the 3 levels in the sidebar of a course page.  You should be redirected to the search page with that topic selected.  If you have run `backpopulate_ocw_topics` in open-discussions, the 3rd level topic should return some search results.

