### PR TITLE
desktop course info toggle

### DIFF
--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -35,13 +35,19 @@
           <main aria-role="main">
             <div class="container-fluid p-0">
               <div class="row m-0">
-                <div class="col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6">
+                <div id="main-content" class="col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6">
+                  <div class="desktop-course-info-button large-and-above-only bg-light shadow-sm border border-right-0 rounded-left">
+                    <div id="desktop-course-info-toggle" class="btn px-2 m-0 navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
+                      data-toggle="collapse">
+                      Hide Course Info
+                    </div>
+                  </div>
                   {{ block "main" . }}{{ end }}
                 </div>
-                <div class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">
-                  {{ partial "chp_partial.html" (dict "partial" "course_info.html" "context" .) }}
-                  {{ partial "chp_partial.html" (dict "partial" "topics.html" "context" .) }}
-                  {{ partial "chp_partial.html" (dict "partial" "course_features.html" "context" .) }}
+                <div id="desktop-course-info" class="col-12 col-lg-4 col-xl-4 px-6 mt-6 large-and-above-only border-left-light">
+                    {{ partial "chp_partial.html" (dict "partial" "course_info.html" "context" .) }}
+                    {{ partial "chp_partial.html" (dict "partial" "topics.html" "context" .) }}
+                    {{ partial "chp_partial.html" (dict "partial" "course_features.html" "context" .) }}
                 </div>
               </div>
             </div>

--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -20,8 +20,8 @@
     {{ partial "mobile_course_info.html" . }}
     {{ block "header" . }}{{ partial "header" . }}{{ end }}
     {{ if not (eq .Params.type "course_home") }}
-    <div class="mobile-course-info-toggle medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
-      <div id="toggle" class="btn px-2 m-0 navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
+    <div class="course-info-toggle medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
+      <div class="btn px-2 m-0 toggle navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
         data-toggle="offcanvas" data-target="#course-info-drawer">
         Course Info
       </div>
@@ -36,8 +36,8 @@
             <div class="container-fluid p-0">
               <div class="row m-0">
                 <div id="main-content" class="col-12 col-lg-8 col-xl-8 px-3 px-md-5 mt-3 mt-lg-6">
-                  <div class="desktop-course-info-button large-and-above-only bg-light shadow-sm border border-right-0 rounded-left">
-                    <div id="desktop-course-info-toggle" class="btn px-2 m-0 navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
+                  <div class="course-info-toggle large-and-above-only bg-light shadow-sm border border-right-0 rounded-left">
+                    <div id="desktop-course-info-toggle" class="btn px-2 m-0 toggle navbar-toggle offcanvas-toggle text-uppercase font-weight-bold"
                       data-toggle="collapse">
                       Hide Course Info
                     </div>

--- a/src/css/course-nav.scss
+++ b/src/css/course-nav.scss
@@ -26,22 +26,13 @@
   }
 }
 
-.mobile-course-info-toggle {
+.course-info-toggle {
   position: absolute;
   right: 0;
   z-index: 10;
+  width: 38px;
 
-  #toggle {
-    writing-mode: vertical-lr;
-  }
-}
-
-.desktop-course-info-button {
-  position: absolute;
-  right: 0;
-  z-index: 10;
-
-  #desktop-course-info-toggle {
+  .toggle {
     writing-mode: vertical-lr;
     transform: rotate(180deg);
   }

--- a/src/css/course-nav.scss
+++ b/src/css/course-nav.scss
@@ -36,6 +36,17 @@
   }
 }
 
+.desktop-course-info-button {
+  position: absolute;
+  right: 0;
+  z-index: 10;
+
+  #desktop-course-info-toggle {
+    writing-mode: vertical-lr;
+    transform: rotate(180deg);
+  }
+}
+
 .course-nav-list-item {
   @include media-breakpoint-up(lg) {
     padding-right: 2rem;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import { initPdfViewers } from "./js/pdf_viewer"
 import { initSentry } from "./js/sentry"
 import { setupEmailSignupForm } from "./js/mailchimp"
 import { rewriteCourseInfoLinks } from "./js/course_info_links"
+import { initDesktopCourseInfoToggle } from "./js/course_info_toggle"
 
 window.jQuery = $
 window.$ = $
@@ -52,5 +53,6 @@ $(document).ready(() => {
   initPdfViewers()
   initSentry()
   rewriteCourseInfoLinks()
+  initDesktopCourseInfoToggle()
   setupEmailSignupForm()
 })

--- a/src/js/course_info_toggle.js
+++ b/src/js/course_info_toggle.js
@@ -1,0 +1,22 @@
+import { HIDE_COURSE_INFO_TEXT, SHOW_COURSE_INFO_TEXT } from "./lib/constants"
+
+export const initDesktopCourseInfoToggle = () => {
+  document
+    .getElementById("desktop-course-info-toggle")
+    .addEventListener("click", () => {
+      const mainContent = document.getElementById("main-content")
+      const desktopCourseInfo = document.getElementById("desktop-course-info")
+      const desktopCourseInfoToggle = document.getElementById(
+        "desktop-course-info-toggle"
+      )
+      desktopCourseInfo.classList.toggle("d-none")
+      mainContent.classList.toggle("col-xl-8")
+      mainContent.classList.toggle("col-lg-8")
+      console.log(desktopCourseInfoToggle.innerText)
+      if (desktopCourseInfoToggle.innerText === HIDE_COURSE_INFO_TEXT) {
+        desktopCourseInfoToggle.innerText = SHOW_COURSE_INFO_TEXT
+      } else {
+        desktopCourseInfoToggle.innerText = HIDE_COURSE_INFO_TEXT
+      }
+    })
+}

--- a/src/js/lib/constants.js
+++ b/src/js/lib/constants.js
@@ -55,3 +55,6 @@ export const DESKTOP = "DESKTOP"
 export const PHONE_WIDTH = 599
 // Based on desktop-wide breakpoint
 export const TABLET_WIDTH = 999
+
+export const HIDE_COURSE_INFO_TEXT = "HIDE COURSE INFO"
+export const SHOW_COURSE_INFO_TEXT = "SHOW COURSE INFO"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/311

#### What's this PR do?
This PR adds a hide / show button to the course info section on the right side of the desktop layout.  When collapsed, the main content area fills the space left over.

#### How should this be manually tested?
Run the site and visit a course page in every browser you have access to, testing that the button properly collapses and expands the course info section on the right.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/99113023-92afb480-25bc-11eb-90da-d7a17215d2c8.png)
![image](https://user-images.githubusercontent.com/12089658/99113054-a0fdd080-25bc-11eb-83c8-69da872a1486.png)

