### PR TITLE
add back in topics and features in the mobile course info drawer

### DIFF
--- a/site/layouts/partials/mobile_course_info.html
+++ b/site/layouts/partials/mobile_course_info.html
@@ -3,4 +3,6 @@
   class="bg-faded pt-3 bg-light navbar-offcanvas navbar-offcanvas-right medium-and-below-only nav-drawer"
 >
   {{ partial "chp_partial.html" (dict "partial" "course_info.html" "context" .) }}
+  {{ partial "chp_partial.html" (dict "partial" "topics.html" "context" .) }}
+  {{ partial "chp_partial.html" (dict "partial" "course_features.html" "context" .) }}
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
When the `course_info.html` partial was split up into its 3 parts, I forgot to reflect those changes in the mobile course info drawer.  This adds them back.

#### How should this be manually tested?
Run the site and assure you can see topics and course features in the mobile course info drawer.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/99006390-5de62380-2510-11eb-998f-6027b2d69c6c.png)

