### PR TITLE
fix search filter title wrapping

### DIFF
--- a/src/css/search-filter.scss
+++ b/src/css/search-filter.scss
@@ -149,7 +149,6 @@
     display: inline-flex;
     align-items: center;
     flex-wrap: nowrap;
-    white-space: nowrap;
     border: 1px solid $font-gray-mid;
     border-radius: 14px;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #337

#### What's this PR do?

changes a CSS rule so that the text in the filter 'bubbles' will wrap (see screenshots if that doesn't make sense)

#### How should this be manually tested?

make sure that some of the long titles work alright.

this is a good filter to test:

http://localhost:3000/search/?d=Electrical%20Engineering%20and%20Computer%20Science

#### Screenshots (if appropriate)

before:
![Screenshot from 2020-11-16 10-07-44](https://user-images.githubusercontent.com/6207644/99268843-ad1fa300-27f3-11eb-9e6f-0bae79134997.png)

after:

![Screenshot from 2020-11-16 10-07-29](https://user-images.githubusercontent.com/6207644/99268814-a55ffe80-27f3-11eb-8c76-e12db4d5d58e.png)

mobile:

![Screenshot from 2020-11-16 10-08-41](https://user-images.githubusercontent.com/6207644/99268967-cde7f880-27f3-11eb-98ab-3d350ab5a5ea.png)



:tada: 