### PR TITLE
Update topics partials to use new data structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/register": "^7.10.5",
     "@mitodl/course-search-utils": "^1.1.1",
-    "@mitodl/ocw-to-hugo": "^1.3.0",
+    "@mitodl/ocw-to-hugo": "^1.3.1",
     "@sentry/browser": "^5.19.0",
     "archiver": "^5.0.0",
     "assets-webpack-plugin": "^3.9.7",

--- a/site/layouts/partials/topic.html
+++ b/site/layouts/partials/topic.html
@@ -13,15 +13,14 @@
   {{ end }}
   <span class="topic-text-wrapper">
     <a class="link-unstyled text-dark font-weight-bold course-info-topic" href="#">
-    {{ title .topic }}
+    {{ title .topic.topic }}
     </a>
   </span>
 </div>
 {{ if gt (len .subtopics) 0 }}
 <div class="pl-4 subtopic-container collapse{{if eq $index 0 }} show{{ end }}" id="subtopic-container_{{ $index }}">
-  {{- $context.Scratch.Set "subtopicIndex" 0 -}}
-  {{ range $subtopic, $specialities := .subtopics }}
-  {{- $subtopicIndex := $context.Scratch.Get "subtopicIndex" -}}
+  {{ range $subtopicIndex, $subtopic := .subtopics }}
+  {{ $specialities := $subtopic.specialities }}
   <div class="position-relative pt-1 pb-1 {{ if gt (len $specialities) 0 }} pl-4{{ end }}">
     {{ if gt (len $specialities) 0 }}
     <a class="topic-toggle"
@@ -34,7 +33,7 @@
     {{ end }}
     <span class="topic-text-wrapper">
       <a class="link-unstyled text-dark font-weight-bold course-info-topic" href="#">
-      {{ title $subtopic }}
+      {{ title $subtopic.subtopic }}
       </a>
     </span>
   </div>
@@ -47,7 +46,6 @@
     </span>
   </div>
   {{ end }}
-  {{- $context.Scratch.Add "subtopicIndex" 1 -}}
   {{ end }}
 </div>
 {{ end }}

--- a/site/layouts/partials/topics.html
+++ b/site/layouts/partials/topics.html
@@ -1,15 +1,11 @@
-{{ if isset .Params "course_info" }}
 {{ $courseInfo := .Params.course_info }}
 <div class="border-bottom-light mb-2">
   <h5 class="font-weight-bold">Topic(s)</h5>
   <ul class="list-unstyled pb-2 m-0">
-    {{- $.Scratch.Set "topicIndex" 0 -}}
-    {{ range $topic, $subtopics := $courseInfo.topics }}
+    {{ range $index, $topic := $courseInfo.topics }}
     <li>
-      {{ partial "topic.html" (dict "context" $ "index" ($.Scratch.Get "topicIndex") "topic" $topic "subtopics" $subtopics) }}
+      {{ partial "topic.html" (dict "index" $index "topic" $topic "subtopics" $topic.subtopics) }}
     </li>
-    {{- $.Scratch.Add "topicIndex" 1 -}}
     {{ end }}
   </ul>
 </div>
-{{ end }}

--- a/site/layouts/partials/topics_summary.html
+++ b/site/layouts/partials/topics_summary.html
@@ -1,10 +1,10 @@
 {{- $topicsList := slice -}}
-{{- range $topic, $subtopics := . -}}
-    {{- if not $subtopics -}}
-        {{- $topicsList = $topicsList | append (title $topic) -}}
+{{- range $topic := . -}}
+    {{- if not $topic.subtopics -}}
+        {{- $topicsList = $topicsList | append (title $topic.topic) -}}
     {{- else -}}
-        {{- range $subtopic, $specialities := $subtopics -}}
-        {{- $topicsList = $topicsList | append (title $subtopic) -}}
+        {{- range $subtopic := $topic.subtopics -}}
+        {{- $topicsList = $topicsList | append (title $subtopic.subtopic) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,10 +1336,10 @@
     query-string "^6.13.1"
     ramda "^0.27.1"
 
-"@mitodl/ocw-to-hugo@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.3.0.tgz#91ccf8732b87a782356a40f506003c1e4ff900c4"
-  integrity sha512-donaHoGo0q1C1H8UahEZ2zgVOnxyngqPQGt3jbca33Fc5LmEVW72oiK2q9cIvjHHvf+DX1A4Bo5iMam1iIAEXQ==
+"@mitodl/ocw-to-hugo@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@mitodl/ocw-to-hugo/-/ocw-to-hugo-1.3.1.tgz#0c638a4a6fcfec249b4ad761d2b9ecbfbcec5378"
+  integrity sha512-HuRfBkCuKTa6TAZwZTA0WIAlJvcYiiQ6x8QQl0ibUCgS/yqUs3xizTfY1NRvOHdLxQ9lIzYqPh0NnsSkh00Twg==
   dependencies:
     aws-sdk "^2.671.0"
     cli-progress "^3.4.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #345 

#### What's this PR do?
Updates partials to use different data structure for topics from https://github.com/mitodl/ocw-to-hugo/pull/119. This preserves the case sensitivity of the topic and subtopic, which allows searches to match more correctly.

#### How should this be manually tested?
You'll need to use an updated version of the parsed JSON to create markdown, from ocw-to-hugo 1.3.1 or later. If you just switch from master to this branch without recreating the markdown you should see some errors about `topics.html`. 

Nothing should look different. In particular you should see topics on the course cards and the topic expander items on the course home page. All topic links should work as before.
