### PR TITLE
Don't activate desktop toggle for other pages

### DIFF
--- a/src/js/course_info_toggle.js
+++ b/src/js/course_info_toggle.js
@@ -1,9 +1,9 @@
 import { HIDE_COURSE_INFO_TEXT, SHOW_COURSE_INFO_TEXT } from "./lib/constants"
 
 export const initDesktopCourseInfoToggle = () => {
-  document
-    .getElementById("desktop-course-info-toggle")
-    .addEventListener("click", () => {
+  const toggleElement = document.getElementById("desktop-course-info-toggle")
+  if (toggleElement) {
+    toggleElement.addEventListener("click", () => {
       const mainContent = document.getElementById("main-content")
       const desktopCourseInfo = document.getElementById("desktop-course-info")
       const desktopCourseInfoToggle = document.getElementById(
@@ -19,4 +19,5 @@ export const initDesktopCourseInfoToggle = () => {
         desktopCourseInfoToggle.innerText = HIDE_COURSE_INFO_TEXT
       }
     })
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes an exception which is thrown when code looks for the course info toggle button, which doesn't exist on every page

#### How should this be manually tested?
You should not see a console error when visiting the home page
