### PR TITLE
Replace material-icons package with CDN version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "lodash.has": "^4.5.2",
     "lodash.toarray": "^4.4.0",
     "lodash.uppercase": "^4.3.0",
-    "material-icons": "^0.3.1",
     "mathjax": "3",
     "mini-css-extract-plugin": "^0.8.0",
     "nanogallery2": "^2.4.2",

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -11,6 +11,7 @@
       <link href="{{ relURL $stylesheet.css }}" rel="stylesheet">
     {{ end }}
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   </head>
   <body>
     <div class="overflow-auto">

--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -12,6 +12,7 @@
   <link href="{{ relURL $stylesheet.css }}" rel="stylesheet">
   {{ end }}
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 
 <body>

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -4,9 +4,6 @@
 @import "~bootstrap/scss/bootstrap";
 @import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
-$material-icons-font-path: "~material-icons/iconfont/";
-
-@import "~material-icons/iconfont/material-icons.scss";
 @import "breakpoints";
 @import "header";
 @import "home";
@@ -217,30 +214,6 @@ table {
 
 .material-icons.md-48 {
   font-size: 48px;
-}
-
-.instructors-icon {
-  @include material-icon("school");
-}
-
-.department-icon {
-  @include material-icon("account_balance");
-}
-
-.topics-icon {
-  @include material-icon("subject");
-}
-
-.course-number-icon {
-  @include material-icon("account_balance");
-}
-
-.term-icon {
-  @include material-icon("today");
-}
-
-.level-icon {
-  @include material-icon("equalizer");
 }
 
 .border-left-light {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8553,11 +8553,6 @@ matchdep@^2.0.0:
     resolve "^1.4.0"
     stack-trace "0.0.10"
 
-material-icons@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/material-icons/-/material-icons-0.3.1.tgz#425e06e2448632d6249d6e1ffe2993682c5b171e"
-  integrity sha512-5Hbj76A6xDPcDZEbM4oxTknhWuMwGWnAHVLLPCEq9eVlcHb0fn4koU9ZeyMy1wjARtDEPAHfd5ZdL2Re5hf0zQ==
-
 mathjax@3:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/mathjax/-/mathjax-3.0.5.tgz#707e703a9c1d95f0790bbd404b895566f459d514"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #312

#### What's this PR do?
Switches to the CDN version of material-icons since it's newer and includes some icons we will need for the course features on #312. The `material-icons` package looks to be third party and hasn't been updated in a couple years.

#### How should this be manually tested?
Click around. Everything should look about the same as before.