### PR TITLE
fix two style oopsies

### DIFF
--- a/site/themes/multi_course/layouts/home.html
+++ b/site/themes/multi_course/layouts/home.html
@@ -13,7 +13,11 @@
       </div>
     </div>
   </div>
-  <div class="d-flex flex-column align-items-center home-banner">
+  <div
+    class="d-flex flex-column align-items-center home-banner"
+    style="background-image: url(/images/homepage_hero.png);"
+    >
+
     <div id="new-desktop-header">
       <div class="contents px-6">
         <div class="left">

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -38,7 +38,6 @@ $spacer8: map-get($spacers, 8);
 }
 
 .home-banner {
-  background-image: url("http://localhost:3000/images/homepage_hero.png");
   background-size: cover;
   background-repeat: no-repeat;
   height: 500px;
@@ -225,7 +224,7 @@ $maxwidth: 1280px;
       img {
         width: 100%;
         object-fit: cover;
-        height: 141px;
+        height: 186px;
       }
 
       .course-level {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

1. fix issue with background-image on the home banner by setting an inline HTML style instead of CSS
2. fix height of course card image on homepage

#### How should this be manually tested?

look at it


#### Screenshots (if appropriate)

![Screenshot from 2020-11-18 09-44-24](https://user-images.githubusercontent.com/6207644/99544835-c145da80-2982-11eb-860e-d448a37f8eea.png)
![Screenshot from 2020-11-18 09-44-57](https://user-images.githubusercontent.com/6207644/99544909-d28ee700-2982-11eb-8714-b6663b1a4074.png)

