### PR TITLE
restrict the course banner to the max content width

### DIFF
--- a/site/layouts/partials/course_banner.html
+++ b/site/layouts/partials/course_banner.html
@@ -1,5 +1,3 @@
-<div id="course-banner" class="p-0">
-  <div class="max-content-width m-auto px-5 py-6">
-    <p class="text-uppercase display-4 font-weight-bold m-0">{{ .Params.course_title }}</p>
-  </div>
+<div id="course-banner" class="max-content-width m-auto px-5 py-6">
+  <p class="text-uppercase display-4 font-weight-bold m-0">{{ .Params.course_title }}</p>
 </div>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/311

#### What's this PR do?
It restricts the course banner to the max content width.

#### How should this be manually tested?
Run the site and display a course page at a resolution higher than the max content width and assure that the course banner does not overflow.

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/99562877-a1b8ad00-2996-11eb-8b4b-3ba3dc2ab573.png)

