### PR TITLE
course page content text style

### DIFF
--- a/site/layouts/partials/course_content.html
+++ b/site/layouts/partials/course_content.html
@@ -3,10 +3,12 @@
 
 <div class="pb-4 rounded">
   <header>
-    <h1 class="text-uppercase font-weight-bold">{{ $currentPage.Title }}</h1>
-    {{ with $currentPage.Params.course_info.subtitle }}
-    <span class="subtitle">{{ . }}</span>
-    {{ end }}
+    <div class="course-section-title-container">
+      <h1 class="text-uppercase font-weight-bold">{{ $currentPage.Title }}</h1>
+      {{ with $currentPage.Params.course_info.subtitle }}
+      <span class="subtitle">{{ . }}</span>
+      {{ end }}
+    </div>
   </header>
   {{ partial "mobile_nav_toggle.html" . }}
   <article class="content pt-2">

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -271,6 +271,8 @@ table {
 }
 
 article.content {
+  font-size: 1rem;
+
   h2 {
     color: $highlight-red;
     font-size: 1.15rem;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -282,11 +282,11 @@ article.content {
   // sometimes the tables can be wide, and on mobile that can ruin the overall page width
   // this forces the table to scroll if it's too wide
   table {
-    display: block;
+    display: table;
     overflow: auto;
 
     thead {
-      background-color: $medium-gray;
+      background-color: $course-blue;
       color: white;
       text-transform: uppercase;
 

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -271,6 +271,12 @@ table {
 }
 
 article.content {
+  h2 {
+    color: $highlight-red;
+    font-size: 1.15rem;
+    text-transform: uppercase;
+  }
+
   // sometimes the tables can be wide, and on mobile that can ruin the overall page width
   // this forces the table to scroll if it's too wide
   table {

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -306,3 +306,8 @@ article.content {
 .course-title-section {
   font-size: 18px;
 }
+
+.course-section-title-container {
+  max-width: 795px;
+  border-bottom: 1px solid $border-dark-color;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/hugo-course-publisher/issues/311

#### What's this PR do?
This PR alters the text styling in course section pages' content to match these mocks:

https://projects.invisionapp.com/d/main/#/console/18609637/435659054/inspect
https://projects.invisionapp.com/d/main/#/console/18609637/435659055/inspect

Note that the alternating grey backgrounds in the mock are currently not feasible and are not included in this PR.

#### How should this be manually tested?
Run the site or visit the deploy preview and ensure that everything looks as it should

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/99579594-61642980-29ac-11eb-8fbb-3eb8bb95f139.png)
![image](https://user-images.githubusercontent.com/12089658/99579611-675a0a80-29ac-11eb-9933-7bca0c7b3f74.png)

