### PR TITLE
fix header and course_banner usage

### DIFF
--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -18,7 +18,7 @@
   <div class="overflow-auto bg-white">
     {{ partial "mobile_course_nav.html" . }}
     {{ partial "mobile_course_info.html" . }}
-    {{ block "header" . }}{{ partial "header" . }}{{ end }}
+    {{ block "header" . }}{{ partial "header" . }}{{ partial "header_placeholder.html" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
     {{ if not $isCourseHomePage }}
     <div class="course-info-toggle medium-and-below-only bg-light shadow-sm border border-right-0 rounded-left">
@@ -28,7 +28,7 @@
       </div>
     </div>
     {{ end }}
-    {{ block "subheader" . }}{{ end }}
+    {{ block "subheader" . }}{{ partial "chp_partial.html" (dict "partial" "course_banner.html" "context" .) }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
         {{ partial "desktop_nav.html" . }}

--- a/site/layouts/course/course_home.html
+++ b/site/layouts/course/course_home.html
@@ -1,10 +1,3 @@
-{{ define "header" }}
-{{ partial "header" . }}
-{{ partial "header_placeholder.html" . }}
-{{ end }}
-{{ define "subheader" }}
-{{ partial "course_banner.html" . }}
-{{ end }}
 {{ define "main" }}
 {{ $courseThumbnailUrl := .CurrentSection.Params.course_thumbnail_image_url }}
 {{ $courseImageUrl := .CurrentSection.Params.course_image_url }}

--- a/site/layouts/course/course_section.html
+++ b/site/layouts/course/course_section.html
@@ -1,10 +1,3 @@
-{{ define "header" }}
-{{ partial "header" . }}
-{{ partial "header_placeholder.html" . }}
-{{ end }}
-{{ define "subheader" }}
-{{ partial "course_banner.html" . }}
-{{ end }}
 {{ define "main" }}
 {{ partial "course_content.html" . }}
 {{ end }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes a bug where the header does not display properly on video and pdf pages

#### How should this be manually tested?
Run the site and visit the deploy preview, ensure that the header is being rendered properly.  Here are a few examples:

http://localhost:3000/courses/ec-711-d-lab-energy-spring-2011/sections/intro-energy-basics-human-power/mitec_711s11_read_react/
http://localhost:3000/courses/ec-711-d-lab-energy-spring-2011/sections/week-7-trip-planning-and-preparations/lecture-7-solar-cookers-creative-capacity-building-trip-preparation/

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/99708753-3b9e5980-2a6c-11eb-8a18-e2291eb62bab.png)

