### PR TITLE
Adjust border radius of carousel card to match image

### DIFF
--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -255,7 +255,8 @@ $maxwidth: 1280px;
 
     .course-card {
       border: 1px solid $border-gray;
-      border-radius: 7px;
+      $radius: 10px;
+      border-radius: $radius;
       height: 381px;
       width: 100%;
 
@@ -267,7 +268,7 @@ $maxwidth: 1280px;
         width: 100%;
         object-fit: cover;
         height: 186px;
-        border-radius: 10px 10px 0 0;
+        border-radius: $radius $radius 0 0;
       }
 
       .course-level {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #380 

#### What's this PR do?
Adjusts `course-card` image radius to match the image border radius

#### How should this be manually tested?
Look at the cards

#### Screenshots (if appropriate)
There are still some stray pixels leaking out. I'm not sure how to fix or if it's worthwhile to do so: 
![Screenshot from 2020-11-19 17-29-42](https://user-images.githubusercontent.com/863262/99732135-f63e5400-2a8c-11eb-926b-3f2e6a9e3c8c.png)

