### PR TITLE
expand example_courses.json

### DIFF
--- a/example_courses.json
+++ b/example_courses.json
@@ -40,6 +40,10 @@
         "res-15-003-shaping-the-future-of-work-15-662x-spring-2016",
         "res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015",
         "res-2-006-girls-who-build-cameras-summer-2016",
-        "res-3-004-visualizing-materials-science-fall-2017"
+        "res-3-004-visualizing-materials-science-fall-2017",
+        "15-667-negotiation-and-conflict-management-spring-2001",
+        "21m-342-composing-for-jazz-orchestra-fall-2008",
+        "18-s997-introduction-to-matlab-programming-fall-2011",
+        "1-124j-foundations-of-software-engineering-fall-2000"
     ]
 }


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

add a series of courses which have had some issue at some point which we fixed. There was the matlab course, where we had a code block issue, a course with a simplecast embed, etc.

this should make it so that the example course set, used in development, is more representative of the range of things that we actually render on the full site.

#### How should this be manually tested?

Make sure that you can run `import:ocw:example_courses` and then build the site without errors.