### PR TITLE
Implement collapse/expand for course info

### DIFF
--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -2,12 +2,14 @@
 {{ $courseInfo := .Params.course_info }}
 {{ $inPanel := .args.inPanel }}
 <div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
-  <div class="course-info-expander d-flex align-items-center">
-    <h4 class="course-info-title font-weight-bold">Course Info</h4>
+  <div class="course-info-expander">
     {{ if not $inPanel }}
-    <a class="expand-link" href="#">
+    <a class="expand-link d-flex align-items-center text-decoration-none" href="#">
+      <h4 class="course-info-title font-weight-bold d-inline m-0">Course Info</h4>
       <span class="material-icons">keyboard_arrow_right</span>
     </a>
+    {{ else }}
+    <h4 class="course-info-title font-weight-bold">Course Info</h4>
     {{ end }}
   </div>
   <div class="position-relative">

--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -1,47 +1,55 @@
 {{ if isset .Params "course_info"  }}
 {{ $courseInfo := .Params.course_info }}
 {{ $inPanel := .args.inPanel }}
-<div class="table-responsive course-info">
-  <h4 class="course-info-title font-weight-bold">Course Info</h4>
-  <table class="table table-borderless {{ if $inPanel }}border-bottom-light{{ end }} mb-2">
-    <tr>
-      <td class="pl-0">Instructor(s):</td>
-      <td>
-        {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.instructors "id" "instructors" "klass" "course-info-instructor") }}
-      </td>
-    </tr>
-    <tr>
-      <td class="pl-0">Course Number:</td>
-      <td>{{ partial "partial_collapse_list.html" (dict "list" $courseInfo.course_numbers "id" "course_numbers" "useLinks" false) }}</td>
-    </tr>
-    <tr>
-      <td class="pl-0">Departments:</td>
-      <td>
-        {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.departments "id" "departments" "klass" "course-info-department") }}
-      </td>
-    </tr>
-    {{ if not $inPanel }}
-    <tr>
-      <td class="pl-0">Topics:</td>
-      <td>
-        {{ partial "topics_oneline.html" . }}
-      </td>
-    </tr>
-    {{ end }}
-    <tr>
-      <td class="pl-0 text-nowrap">As Taught In:</td>
-      <td>
-        {{ $courseInfo.term }}
-      </td>
-    </tr>
-    <tr>
-      <td class="pl-0 pb-3">Level:</td>
-      <td>
-        <a href="#" class="course-info-level">
-          {{ $courseInfo.level }}
-        </a>
-      </td>
-    </tr>
-  </table>
+<div class="table-responsive course-info collapsed">
+  <div class="course-info-expander d-flex align-items-center">
+    <h4 class="course-info-title font-weight-bold">Course Info</h4>
+    <a class="expand-link" href="#">
+      <span class="material-icons">keyboard_arrow_right</span>
+    </a>
+  </div>
+  <div class="position-relative">
+    <div class="opaque-layer"></div>
+    <table class="table table-borderless {{ if $inPanel }}border-bottom-light{{ end }} mb-2">
+      <tr>
+        <td class="pl-0">Instructor(s):</td>
+        <td>
+          {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.instructors "id" "instructors" "klass" "course-info-instructor") }}
+        </td>
+      </tr>
+      <tr>
+        <td class="pl-0">Course Number:</td>
+        <td>{{ partial "partial_collapse_list.html" (dict "list" $courseInfo.course_numbers "id" "course_numbers" "useLinks" false) }}</td>
+      </tr>
+      <tr>
+        <td class="pl-0">Departments:</td>
+        <td>
+          {{ partial "partial_collapse_list.html" (dict "list" $courseInfo.departments "id" "departments" "klass" "course-info-department") }}
+        </td>
+      </tr>
+      {{ if not $inPanel }}
+      <tr>
+        <td class="pl-0">Topics:</td>
+        <td>
+          {{ partial "topics_oneline.html" . }}
+        </td>
+      </tr>
+      {{ end }}
+      <tr>
+        <td class="pl-0 text-nowrap">As Taught In:</td>
+        <td>
+          {{ $courseInfo.term }}
+        </td>
+      </tr>
+      <tr>
+        <td class="pl-0 pb-3">Level:</td>
+        <td>
+          <a href="#" class="course-info-level">
+            {{ $courseInfo.level }}
+          </a>
+        </td>
+      </tr>
+    </table>
+  </div>
 </div>
 {{ end }}

--- a/site/layouts/partials/course_info.html
+++ b/site/layouts/partials/course_info.html
@@ -1,12 +1,14 @@
 {{ if isset .Params "course_info"  }}
 {{ $courseInfo := .Params.course_info }}
 {{ $inPanel := .args.inPanel }}
-<div class="table-responsive course-info collapsed">
+<div class="table-responsive course-info {{ if not $inPanel }}collapsed{{ end }}">
   <div class="course-info-expander d-flex align-items-center">
     <h4 class="course-info-title font-weight-bold">Course Info</h4>
+    {{ if not $inPanel }}
     <a class="expand-link" href="#">
       <span class="material-icons">keyboard_arrow_right</span>
     </a>
+    {{ end }}
   </div>
   <div class="position-relative">
     <div class="opaque-layer"></div>

--- a/src/css/course-info.scss
+++ b/src/css/course-info.scss
@@ -1,11 +1,37 @@
 .course-info {
   overflow: hidden;
+  $collapsedHeight: 130px;
+  $opaqueLayerHeight: 30px;
+
+  &.collapsed {
+    table {
+      display: block;
+      position: relative;
+      height: $collapsedHeight;
+      margin-bottom: 0 !important;
+    }
+
+    .opaque-layer {
+      position: absolute;
+      bottom: 0;
+      height: $opaqueLayerHeight;
+      width: 100%;
+      background: linear-gradient(to bottom, transparent, white);
+      z-index: 1;
+    }
+  }
 
   table {
     tr {
       td:nth-child(1) {
         color: $podcast-border-gray;
       }
+    }
+  }
+
+  .course-info-expander {
+    a {
+      margin-left: 150px;
     }
   }
 }

--- a/src/css/course-info.scss
+++ b/src/css/course-info.scss
@@ -30,7 +30,7 @@
   }
 
   .course-info-expander {
-    a {
+    .material-icons {
       margin-left: 150px;
     }
   }

--- a/src/css/course-info.scss
+++ b/src/css/course-info.scss
@@ -1,6 +1,6 @@
 .course-info {
   overflow: hidden;
-  $collapsedHeight: 130px;
+  $collapsedHeight: 70px;
   $opaqueLayerHeight: 30px;
 
   &.collapsed {

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import { initSentry } from "./js/sentry"
 import { setupEmailSignupForm } from "./js/mailchimp"
 import { rewriteCourseInfoLinks } from "./js/course_info_links"
 import { initDesktopCourseInfoToggle } from "./js/course_info_toggle"
+import { initCourseInfoExpander } from "./js/course_expander"
 
 window.jQuery = $
 window.$ = $
@@ -47,4 +48,5 @@ $(document).ready(() => {
   rewriteCourseInfoLinks()
   initDesktopCourseInfoToggle()
   setupEmailSignupForm()
+  initCourseInfoExpander()
 })

--- a/src/js/course_expander.js
+++ b/src/js/course_expander.js
@@ -1,0 +1,30 @@
+const toggleExpand = (button, container) => {
+  const expanded = button.classList.contains("expanded")
+  if (expanded) {
+    button.classList.remove("expanded")
+    container.classList.add("collapsed")
+    button.querySelector(".material-icons").textContent = "keyboard_arrow_right"
+  } else {
+    button.classList.add("expanded")
+    container.classList.remove("collapsed")
+    button.querySelector(".material-icons").textContent = "keyboard_arrow_down"
+  }
+}
+
+const initCourseInfoExpander = () => {
+  for (const container of document.querySelectorAll(".course-info")) {
+    const expanderButton = container.querySelector(".expand-link")
+    expanderButton.addEventListener("click", event => {
+      event.preventDefault()
+      toggleExpand(expanderButton, container)
+    })
+    expanderButton.addEventListener("keypress", event => {
+      if (event.key === "Enter") {
+        event.preventDefault()
+        toggleExpand(expanderButton, container)
+      }
+    })
+  }
+}
+
+export { initCourseInfoExpander }

--- a/src/js/course_expander.js
+++ b/src/js/course_expander.js
@@ -14,16 +14,18 @@ const toggleExpand = (button, container) => {
 const initCourseInfoExpander = () => {
   for (const container of document.querySelectorAll(".course-info")) {
     const expanderButton = container.querySelector(".expand-link")
-    expanderButton.addEventListener("click", event => {
-      event.preventDefault()
-      toggleExpand(expanderButton, container)
-    })
-    expanderButton.addEventListener("keypress", event => {
-      if (event.key === "Enter") {
+    if (expanderButton) {
+      expanderButton.addEventListener("click", event => {
         event.preventDefault()
         toggleExpand(expanderButton, container)
-      }
-    })
+      })
+      expanderButton.addEventListener("keypress", event => {
+        if (event.key === "Enter") {
+          event.preventDefault()
+          toggleExpand(expanderButton, container)
+        }
+      })
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #312 

#### What's this PR do?
Adds a button to toggle course info

#### How should this be manually tested?
Click the expander button

#### Screenshots (if appropriate)
Desktop:
![Screenshot from 2020-11-20 18-15-09](https://user-images.githubusercontent.com/863262/99858928-9d3df100-2b5c-11eb-8d44-097dd71231eb.png)
![Screenshot from 2020-11-20 18-15-21](https://user-images.githubusercontent.com/863262/99858932-9fa04b00-2b5c-11eb-9c06-122d17799518.png)

Mobile:
![Screenshot_2020-11-20 Course Home Computer System Engineering Electrical Engineering and Computer Science MIT OpenCourseWare](https://user-images.githubusercontent.com/863262/99858945-a7f88600-2b5c-11eb-85ca-a2b1da3e00ed.png)
![Screenshot_2020-11-20 Course Home Computer System Engineering Electrical Engineering and Computer Science MIT OpenCourseWare(1)](https://user-images.githubusercontent.com/863262/99858951-ab8c0d00-2b5c-11eb-9b01-13cecac0102a.png)
