### PR TITLE
fix image caption / image alt text issue

### DIFF
--- a/site/layouts/course/course_home.html
+++ b/site/layouts/course/course_home.html
@@ -7,13 +7,15 @@
       <div class="col-lg-4 d-none d-lg-block">
         <div class="d-flex flex-column image-with-caption">
           <img class="course-image" src="
-          {{- if hasPrefix $courseImageUrl "http" -}}
-            {{ $courseImageUrl }}
-          {{- else -}}
-            {{ relURL $courseImageUrl }}
-        {{- end -}}" />
+            {{- if hasPrefix $courseImageUrl "http" -}}
+              {{ $courseImageUrl }}
+            {{- else -}}
+              {{ relURL $courseImageUrl }}
+            {{- end -}}"
+            alt="{{ .CurrentSection.Params.course_image_alternate_text }}"
+          />
           <span class="caption p-3">
-            {{ .CurrentSection.Params.course_image_alternate_text }}
+            {{ .CurrentSection.Params.course_image_caption_text | safeHTML }}
           </span>
         </div>
       </div>

--- a/src/css/course-home.scss
+++ b/src/css/course-home.scss
@@ -20,6 +20,10 @@
 
     .caption {
       border-top: 1px solid $border-dark-color;
+
+      p {
+        margin-bottom: 0;
+      }
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #395

#### What's this PR do?

we were rendering the alt text as the caption previously. this instead renders the alt text for the course image as alt text, and renders the caption text in the caption.

#### How should this be manually tested?

check out a few courses. the image captions should be rendered correctly on the course home page, and the image should also have appropriate alt text.

#### Screenshots (if appropriate)

show the image highlighted in the issue:

![Screenshot from 2020-11-23 09-45-08](https://user-images.githubusercontent.com/6207644/99975848-b61ef000-2d70-11eb-8657-af4dc8b61386.png)
![Screenshot from 2020-11-23 09-44-53](https://user-images.githubusercontent.com/6207644/99975851-b61ef000-2d70-11eb-8a19-3f6289b773a3.png)
