### PR TITLE
make the course banner text a link to the course home page

### DIFF
--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -16,7 +16,7 @@
       </div>
     </div>
     {{ end }}
-    {{ block "subheader" . }}{{ partial "chp_partial.html" (dict "partial" "course_banner.html" "context" .) }}{{ end }}
+    {{ block "subheader" . }}{{ partial "course_banner.html" . }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
         {{ partial "desktop_nav.html" . }}

--- a/site/layouts/partials/course_banner.html
+++ b/site/layouts/partials/course_banner.html
@@ -1,5 +1,19 @@
+{{ $bannerClass := "text-uppercase display-4 font-weight-bold m-0 text-white" }}
+{{ $currentPage := . }}
 <div id="course-banner" class="p-0">
   <div class="max-content-width m-auto px-5 py-6">
-    <p class="text-uppercase display-4 font-weight-bold m-0">{{ .Params.course_title }}</p>
+    {{ if (isset $currentPage.Params "course_id") }}
+      {{ $courseId := $currentPage.Params.course_id }}
+      {{ $menu := index .Site.Menus $courseId }}
+      {{ $menuItem := index $menu 0 }}
+      <a
+        class="{{ $bannerClass }}"
+        href="{{ $menuItem.URL | relURL }}"
+      >{{ .Params.course_title }}</a>
+    {{ else }}
+      <p class="{{ $bannerClass }}">
+         {{ .Params.course_title }}
+      </p>
+    {{ end }}
   </div>
 </div>

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -62,6 +62,10 @@ $desktop-header-height: 70px;
 #course-banner {
   color: $white;
   background-color: $course-blue;
+
+  a {
+    text-decoration: none;
+  }
 }
 
 .header-placeholder {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

none, Ferdi just said we want to do this

#### What's this PR do?

this makes the text in the course header (the title with blue background at the top) into a link to the course home page.

#### How should this be manually tested?

you should just make sure it's there and the link works correctly from all course pages.

I couldn't get this to work with the `chp_partial` so I followed the way we do it for the nav partial - possibly this is an incorrect approach but I couldn't get past an error I was getting with the `chp_partial`.