### PR TITLE
carousel image should be a link too

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -34,7 +34,9 @@
                                 {{ end }}
                                         <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
                                             <div class="course-card bg-white">
-                                                <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
+                                                <a href="{{ .Permalink }}">
+                                                  <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
+                                                </a>
                                                 <div class="course-card-content p-3">
                                                     <div class="course-level">
                                                         {{ index $info.course_numbers 0 }} | {{ $info.level }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #369

#### What's this PR do?

adds a link to wrap around the course images, so the user can click on them.

#### How should this be manually tested?

visit the home page, and you should be able to click through to various courses by clicking on their images in the course carousel.