### PR TITLE
fix course feature spacing

### DIFF
--- a/site/layouts/partials/course_feature.html
+++ b/site/layouts/partials/course_feature.html
@@ -1,5 +1,5 @@
-<div class="d-inline-flex pr-5 font-weight-bold align-items-center">
-  <i class="course-feature-icon material-icons h2 pr-4">
+<div class="d-inline-flex pr-5 pb-2 font-weight-bold align-items-center">
+  <i class="course-feature-icon material-icons h2 pr-2 mb-0">
     {{ if eq .feature "AV faculty introductions" }}
     groups
     {{ else if eq .feature "AV lectures" }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #385

#### What's this PR do?

this just tweaks the spacing around the icons and the text for the 'course features' widget, to match the mockup more closely.

#### How should this be manually tested?

Just make sure it looks alright to you I think.


#### Screenshots (if appropriate)

![Screenshot from 2020-11-23 12-06-13](https://user-images.githubusercontent.com/6207644/99999898-d2318a00-2d8e-11eb-8174-64eb635450bb.png)
