### PR TITLE
Add read more link for course description

### DIFF
--- a/site/layouts/course/course_home.html
+++ b/site/layouts/course/course_home.html
@@ -3,6 +3,8 @@
 {{ $courseData := index .Site.Data.courses $courseId }}
 {{ $courseThumbnailUrl := $courseData.course_thumbnail_image_url }}
 {{ $courseImageUrl := $courseData.course_image_url }}
+<!-- the number here is a estimate, a count of 5 lines of characters on a sample course at minimum browser width -->
+{{ $shouldCollapseContent := gt (len .Content) 320 }}
 <div class="homepage-content d-flex">
   <div class="container-fluid pt-0 pb-4">
     <div class="row px-3 pb-2 justify-content-between">
@@ -22,9 +24,16 @@
         </div>
       </div>
       {{ partial "mobile_nav_toggle.html" . }}
-      <div class="col-lg-8">
+      <div class="col-lg-8 course-description {{ if $shouldCollapseContent }}collapsed{{ end }}">
         <h4 class="font-weight-bold pt-2 course-description-title">Course Description</h4>
         <div class="mb-3 course-description">{{- .Content -}}</div>
+        <div class="mb-3">
+          {{ if $shouldCollapseContent }}
+            <button class="expand-link">
+              <span class="text">Read More</span> <i class="material-icons">keyboard_arrow_right</i>
+            </button>
+          {{ end }}
+        </div>
         {{ partial "course_info.html" (dict "context" . "inPanel" false) }}
       </div>
     </div>

--- a/src/css/course-info.scss
+++ b/src/css/course-info.scss
@@ -123,3 +123,25 @@
 .topic-toggle[aria-expanded="true"] > i:after {
   content: "expand_more" !important;
 }
+
+.course-description {
+  &.collapsed {
+    .description {
+      max-height: 6rem;
+      overflow: hidden;
+    }
+  }
+
+  .expand-link {
+    display: flex;
+    align-items: center;
+    border: 0;
+    padding: 0;
+    background-color: white;
+    color: $course-blue;
+
+    .material-icons {
+      color: black;
+    }
+  }
+}

--- a/src/js/course_expander.js
+++ b/src/js/course_expander.js
@@ -1,5 +1,6 @@
 const toggleExpand = (button, container) => {
   const expanded = button.classList.contains("expanded")
+  const text = button.querySelector(".text")
   if (expanded) {
     button.classList.remove("expanded")
     container.classList.add("collapsed")
@@ -9,11 +10,32 @@ const toggleExpand = (button, container) => {
     container.classList.remove("collapsed")
     button.querySelector(".material-icons").textContent = "keyboard_arrow_down"
   }
+
+  if (text) {
+    text.innerText = expanded ? "Read More" : "Show Less"
+  }
 }
 
 const initCourseInfoExpander = () => {
   for (const container of document.querySelectorAll(".course-info")) {
     const expanderButton = container.querySelector(".expand-link")
+    if (expanderButton) {
+      expanderButton.addEventListener("click", event => {
+        event.preventDefault()
+        toggleExpand(expanderButton, container)
+      })
+      expanderButton.addEventListener("keypress", event => {
+        if (event.key === "Enter") {
+          event.preventDefault()
+          toggleExpand(expanderButton, container)
+        }
+      })
+    }
+  }
+
+  for (const container of document.querySelectorAll(".course-description")) {
+    const expanderButton = container.querySelector(".expand-link")
+    console.log("cont", container, expanderButton)
     if (expanderButton) {
       expanderButton.addEventListener("click", event => {
         event.preventDefault()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #312 

#### What's this PR do?
This implements the read more link in the issue which should finish the items listed in #312. I added `react-clamp-lines` since there wasn't an obvious vanilla JS or CSS way to do this and the package doesn't pull in any other dependencies.

The course description is part of the original HTML. The JS will take that HTML, remove the original copy, and render it as a react element with `ClampLines`. `ClampLines` deals with raw text so I made a modification allowing it to display the original html if the description was expanded. There is some DOM manipulation from the React component so let me know if anything appears to glitch.

Caveats: This won't look quite right if there is an image at the top of the course description. Also, the "Read more" and "Show less" links will appear on their own line. I don't know if there's a way to work around this since the course description is HTML and it's unclear how to manipulate the HTML to add the link as an inline element so that it looks correct.

Also, you will see the browser show the old version before showing the collapsed version a second later when the JS finished loading. I don't think we can workaround that without moving to an approach like the CSS one in #396.

#### How should this be manually tested?
Expand and collapse the link. Try it for different kinds of course descriptions, for example large, small, with embedded content, etc.

#### Screenshots (if appropriate)
Desktop, collapsed:
![Screenshot from 2020-11-23 16-10-11](https://user-images.githubusercontent.com/863262/100016104-ec776200-2da6-11eb-805a-ae90b533b315.png)
Desktop, expanded:
![Screenshot from 2020-11-23 16-10-24](https://user-images.githubusercontent.com/863262/100016148-fa2ce780-2da6-11eb-9a33-af4bad31645c.png)

Mobile, collapsed:
![Screenshot from 2020-11-23 16-10-52](https://user-images.githubusercontent.com/863262/100016174-01ec8c00-2da7-11eb-9a3a-6b7c87d972fc.png)
Mobile, expanded:
![Screenshot from 2020-11-23 16-11-09](https://user-images.githubusercontent.com/863262/100016198-0a44c700-2da7-11eb-94a4-7316e1c3598b.png)

Another course with less than 5 lines for the description. It should appear the same as before.
Desktop:
![Screenshot from 2020-11-23 16-11-29](https://user-images.githubusercontent.com/863262/100016236-14ff5c00-2da7-11eb-8875-2c29fb66f273.png)
Mobile:
![Screenshot from 2020-11-23 16-11-41](https://user-images.githubusercontent.com/863262/100016276-27799580-2da7-11eb-857d-5199be2b9f4b.png)
