### PR TITLE
add hover effect, add some padding so it's visible

### DIFF
--- a/site/layouts/partials/home_course_cards.html
+++ b/site/layouts/partials/home_course_cards.html
@@ -33,7 +33,7 @@
                                     <div class="carousel-item {{ if not $isMobile }}row{{end}} {{ if eq $group 0 }}active{{ end }}">
                                 {{ end }}
                                         <div class="course-card-wrapper {{ if not $isMobile }}col-{{ (div 12 $itemsInCarousel) }}{{ end }} w-100 d-flex justify-content-center">
-                                            <div class="course-card bg-white">
+                                            <div class="course-card card bg-white">
                                                 <a href="{{ .Permalink }}">
                                                   <img src="{{ .Params.course_image_url }}" alt="Thumbnail for {{ .Params.course_title }}"/>
                                                 </a>

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -299,12 +299,20 @@ $maxwidth: 1280px;
 
       .carousel-item {
         margin-left: 0;
+
+        @include media-breakpoint-up(md) {
+          padding: 0 10px;
+        }
       }
     }
 
     .carousel-header {
       max-width: $maxwidth;
       margin: 0;
+
+      @include media-breakpoint-up(md) {
+        padding: 0 10px;
+      }
 
       @include media-breakpoint-down(xs) {
         h3 {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #368

#### What's this PR do?

this adds the `.card` class to our course-cards on the home page, so that they get the hover effect that we want.

#### How should this be manually tested?

check out the homepage at a variety of widths. Make sure that the cards have a box-shadow when you hover over them, and that nothing is too weird.

#### Screenshots (if appropriate)

![hoverhover](https://user-images.githubusercontent.com/6207644/100112459-3d399a00-2e3d-11eb-9823-2de8b791405d.png)
