### PR TITLE
Up the z-index of the layer of collapsed overlay

### DIFF
--- a/src/css/course-info.scss
+++ b/src/css/course-info.scss
@@ -17,7 +17,7 @@
       height: $opaqueLayerHeight;
       width: 100%;
       background: linear-gradient(to bottom, transparent, white);
-      z-index: 1;
+      z-index: 8;
     }
   }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Increases z-index of the overlay on the gradient area at the bottom of the course info overlay so it stays visible. 

#### How should this be manually tested?
See https://ocwnext.odl.mit.edu/courses/8-01sc-classical-mechanics-fall-2016/ to reproduce the issue. 

![Screenshot from 2020-11-24 15-33-39](https://user-images.githubusercontent.com/863262/100148217-72101600-2e6a-11eb-945d-18f6923c0743.png)

If you click the caret at the bottom which expands the instructor list, the semi-transparent overlay will disappear. If you do the same on this PR the overlay should remain visible.