### PR TITLE
Use coursenum instead of course_id in search results

### DIFF
--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -72,7 +72,7 @@ export function LearningResourceDisplay(props) {
         <div className="lr-row resource-type-audience-certificates">
           {!isResource ? (
             <div className="resource-type">
-              {`${object.course_id}${object.level ? " | " : ""}${object.level}`}
+              {`${object.coursenum}${object.level ? " | " : ""}${object.level}`}
             </div>
           ) : null}
         </div>
@@ -96,9 +96,7 @@ export function LearningResourceDisplay(props) {
           <div className="lr-row subtitles lr-subheader" tabIndex="0">
             <a href={`/courses/${object.run_slug}`}>
               <Dotdotdot clamp={3}>
-                {object.course_id ?
-                  `${object.course_id.split("+").reverse()[0]} ` :
-                  ""}
+                {object.coursenum ? `${object.coursenum} ` : ""}
                 {object.run_title}
               </Dotdotdot>
             </a>

--- a/src/js/components/SearchResult.test.js
+++ b/src/js/components/SearchResult.test.js
@@ -72,7 +72,7 @@ describe("SearchResult component", () => {
         .find(".subtitles")
         .first()
         .text()
-    ).toBe(`${object.course_id.split("+").reverse()[0]} ${object.run_title}`)
+    ).toBe(`${object.coursenum} ${object.run_title}`)
     expect(
       wrapper
         .find(".subtitles")

--- a/src/js/factories/search.js
+++ b/src/js/factories/search.js
@@ -79,7 +79,8 @@ export const makeRun = () => {
 
 export const makeCourseResult = () => ({
   id:                casual.integer(1, 1000),
-  course_id:         `course_${String(casual.random)}`,
+  course_id:         `course+${String(casual.random)}`,
+  coursenum:         String(casual.random),
   title:             casual.title,
   url:               casual.url,
   image_src:         "http://image.medium.url",
@@ -101,6 +102,7 @@ export const makeCourseResult = () => ({
 export const makeResourceFileResult = () => ({
   id:            casual.integer(1, 1000),
   course_id:     `course_${String(casual.random)}`,
+  coursenum:     String(casual.random),
   title:         casual.title,
   url:           casual.url,
   image_src:     "http://image.medium.url",

--- a/src/js/lib/search.js
+++ b/src/js/lib/search.js
@@ -456,6 +456,7 @@ export const searchResultToLearningResource = result => ({
   url:           getResultUrl(result) || null,
   short_url:     result.short_url || null,
   course_id:     result.course_id || null,
+  coursenum:     result.coursenum || null,
   description:   result.short_description || null
 })
 


### PR DESCRIPTION
~~Blocked by https://github.com/mitodl/open-discussions/pull/3245~~

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/open-discussions/issues/3243

#### What's this PR do?
Uses `coursenum` from search results instead of `course_id` for the course number in the search result card subtitle

#### How should this be manually tested?
- Reindex open-discussions after PR https://github.com/mitodl/open-discussions/pull/3245 is applied.
- Search for courses for "18.01", you should get back 2 results, same title with different thumbnails, and the subtitle on the results should show "18.01" and not something like "aef8923sdfdf12+18.01"

