### PR TITLE
remove chp_partial.html

### DIFF
--- a/site/themes/multi_course/layouts/partials/chp_partial.html
+++ b/site/themes/multi_course/layouts/partials/chp_partial.html
@@ -1,7 +1,0 @@
-{{ $partial := .partial }}
-{{ $context := .context }}
-{{ $courseId := .context.Params.course_id }}
-{{ $args := .args | default (dict) }}
-{{ range first 1 (where $context.FirstSection.Sections ".Params.course_id" $courseId) }}
-  {{ partial $partial (dict "Params" .Params "args" $args) }}
-{{ end }}

--- a/site/themes/single_course/layouts/partials/chp_partial.html
+++ b/site/themes/single_course/layouts/partials/chp_partial.html
@@ -1,2 +1,0 @@
-{{ $args := .args | default (dict) }}
-{{ partial .partial (dict "Params" .context.Params "args" $args) }}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hugo-course-publisher/issues/372

#### What's this PR do?
Removes both the `multi_course` and `single_course` versions of `chp_partial.html` as it's no longer necessary since course metadata is now being stored in Data Templates.

#### How should this be manually tested?
Make sure the site still builds okay, ensure you see no references to `chp_partial.html`

