### PR TITLE
speedier nav implementation

### DIFF
--- a/site/assets/navigation.js
+++ b/site/assets/navigation.js
@@ -1,0 +1,24 @@
+function courseNav () {
+  document.querySelectorAll(".course-nav").forEach(navEl => {
+    // set .active on the currently active link
+    navEl.querySelectorAll(".nav-link").forEach(navLinkEl => {
+      if (navLinkEl.getAttribute('href') === window.location.pathname) {
+        navLinkEl.classList.add("active")
+      }
+    })
+
+    const activeEl = navEl.querySelector("a.nav-link.active")
+
+    // iterate through nav items, find any that are parents of the active link, expanded if needed
+    navEl.querySelectorAll(".course-nav-list-item").forEach(navItemEl => {
+      const collapseEl = navItemEl.querySelector(".collapse")
+      if (collapseEl && collapseEl.contains(activeEl)) {
+        collapseEl.classList.add("show")
+        navItemEl
+          .querySelector(".course-nav-section-toggle")
+          .setAttribute("aria-expanded", true)
+      }
+    })
+  })
+}
+courseNav()

--- a/site/layouts/course/baseof.html
+++ b/site/layouts/course/baseof.html
@@ -3,7 +3,7 @@
   {{ partial "head.html" . }}
 <body class="course-home-page">
   <div class="overflow-auto">
-    {{ partial "mobile_course_nav.html" . }}
+    {{ partialCached "mobile_course_nav.html" . .Params.course_id }}
     {{ partialCached "mobile_course_info.html" . .Params.course_id }}
     {{ block "header" . }}{{ partialCached "header" . }}{{ partialCached "header_placeholder.html" . }}{{ end }}
     {{ $isCourseHomePage := (eq .Params.layout "course_home") }}
@@ -18,7 +18,7 @@
     {{ block "subheader" . }}{{ partialCached "course_banner.html" . .Params.course_id }}{{ end }}
     <div class="container-fluid">
       <div class="row outer-wrapper">
-        {{ partial "desktop_nav.html" . }}
+        {{ partialCached "desktop_nav.html" . .Params.course_id }}
         <div class="left-col-bg"></div>
         <div id="main-content-wrapper" class="col-lg-9 p-0 bg-white">
           <main aria-role="main">
@@ -64,8 +64,8 @@
         message: ["[Math Error]"]
       }
     }
-
   </script>
+  {{ partialCached "navigation_js.html" . }}
   {{ $main := .Site.Data.webpack.main }}
   {{ $mathjax := .Site.Data.webpack.mathjax }}
 

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -4,7 +4,7 @@
 <nav id="course-nav" class="course-nav">
   <ul class="w-100 m-auto list-unstyled">
     {{ range $menu }}
-      {{ partial "nav_item.html" (dict "menuItem" . "currentPage" $currentPage "courseId" $courseId) }}
+      {{ partial "nav_item.html" (dict "menuItem" .) }}
     {{ end }}
   </ul>
 </nav>

--- a/site/layouts/partials/nav_item.html
+++ b/site/layouts/partials/nav_item.html
@@ -1,16 +1,12 @@
 {{ $menuItem := .menuItem }}
 {{ $id := .menuItem.Identifier }}
-{{ $currentPage := .currentPage }}
-{{ $courseId := .courseId }}
 {{ $hasParent := isset . "parentId" }}
 {{ $hasChildren := .menuItem.HasChildren }}
-{{ $isMenuCurrent := $currentPage.IsMenuCurrent $courseId .menuItem }}
-{{ $hasMenuCurrent := $currentPage.HasMenuCurrent $courseId .menuItem }}
 
-<li class="course-nav-list-item{{ if $hasParent }} course-nav-list-item-child{{ end }}{{ if $isMenuCurrent }} active{{ end }}">
-  <div class="position-relative a-wrapper pt-2 pb-2{{ if $hasChildren }} pr-3{{ end }}{{ if $isMenuCurrent }} active{{ end }}">
+<li class="course-nav-list-item{{ if $hasParent }} course-nav-list-item-child{{ end }}">
+  <div class="position-relative a-wrapper pt-2 pb-2{{ if $hasChildren }} pr-3{{ end }}">
     <span class="course-nav-text-wrapper">
-      <a class="text-uppercase text-dark{{ if $isMenuCurrent }} active{{ end }}"
+      <a class="text-uppercase text-dark nav-link"
         href="{{ .menuItem.URL | relURL }}">
         {{ .menuItem.Name }}
       </a>
@@ -20,7 +16,7 @@
       href="#nav-container_{{ .menuItem.Identifier }}" 
       data-toggle="collapse" 
       aria-controls="nav-container_{{ .menuItem.Identifier }}" 
-      aria-expanded="{{ if or $isMenuCurrent $hasMenuCurrent }}true{{ end }}">
+      aria-expanded="">
       <i class="material-icons md-18"></i>
     </a>
     {{ end }}
@@ -28,11 +24,11 @@
   {{ if or (not $hasParent) $hasChildren }}
   <span class="medium-and-below-only"><hr/></span>
   {{ end }}
-  <div class="collapse{{ if or $isMenuCurrent $hasMenuCurrent }} show{{ end }}" 
+  <div class="collapse" 
     id="nav-container_{{ .menuItem.Identifier }}">
     <ul class="course-nav-child-nav m-auto">
       {{ range .menuItem.Children }}
-        {{ partial "nav_item.html" (dict "menuItem" . "currentPage" $currentPage "courseId" $courseId "parentId" $id ) }}
+        {{ partial "nav_item.html" (dict "menuItem" . "parentId" $id ) }}
       {{ end }}
     </ul>
   </div>

--- a/site/layouts/partials/navigation_js.html
+++ b/site/layouts/partials/navigation_js.html
@@ -1,0 +1,5 @@
+{{ $navjs := resources.Get "navigation.js" }}
+{{ $minified := $navjs | resources.Minify }}
+<script>
+{{ $minified.Content | safeJS }}
+</script>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, working on speeding up the hugo build.

#### What's this PR do?

implements a nav solution for the course pages which can be cached across courses. it is still recursive, to render the children and so on, but figuring out when links should have `.active` and when the sections should be expanded is now done with a simple JS function instead of in Hugo. This means that the partial can be rendered just once per course.

I wrote a small JS function to do the work of applying `.active` and so on. Putting it in the webpack JS bundle lead to some yuckiness where the user would see a little flash, since `.active` is applied a bit after startup. So to get around that I experimented with just writing the function directly in the `<script>` tag in the course `baseof.html` template. That worked well, but I think we don't really want to have a random JS snippet living in our HTML template.

So instead I was able to use Hugo's built-in asset pipeline, by writing the JS in `site/assets/navigation.js`. Then I was basically able to use Hugo asset pipeline functions to minify it and paste it into our template, using a partial called `navigation_js.html`. This is a bit different than our normal JS workflow for the site, but we'll likely only be using for this small feature, and it's using only Hugo builtin functionality, so I think it's ok.

#### How should this be manually tested?

I think the key thing is to exercise the nav pretty heavily. Poke at it and try to find somewhere where this solution breaks, try a whole bunch of courses, etc.

some performance testing I did:

rendering `example_courses.json` on this branch:

```
                   |  EN   
-------------------+-------
  Pages            | 8585  
  Paginator pages  |    0  
  Non-page files   |    0  
  Static files     |  409  
  Processed images |    0  
  Aliases          |    0  
  Sitemaps         |    1  
  Cleaned          |    0  

Total in 6922 ms
```

vs master:

```
                   |  EN   
-------------------+-------
  Pages            | 8585  
  Paginator pages  |    0  
  Non-page files   |    0  
  Static files     |  409  
  Processed images |    0  
  Aliases          |    0  
  Sitemaps         |    1  
  Cleaned          |    0  

Total in 10681 ms
```

I think the speed boost will possibly be larger on production, although I'm not sure.