### PR TITLE
Fix CSS Typo for read more link on course description

### DIFF
--- a/site/layouts/course/course_home.html
+++ b/site/layouts/course/course_home.html
@@ -26,7 +26,7 @@
       {{ partial "mobile_nav_toggle.html" . }}
       <div class="col-lg-8 course-description {{ if $shouldCollapseContent }}collapsed{{ end }}">
         <h4 class="font-weight-bold pt-2 course-description-title">Course Description</h4>
-        <div class="mb-3 course-description">{{- .Content -}}</div>
+        <div class="mb-3 description">{{- .Content -}}</div>
         <div class="mb-3">
           {{ if $shouldCollapseContent }}
             <button class="expand-link">


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes a merge conflict affecting #410 

#### What's this PR do?
Updates the CSS class

#### How should this be manually tested?
The read more link on the course description should expand and contract on a course home page
