### PR TITLE
github actions for netlify, google pagespeed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,123 @@
+name: Deploy PR build and run Lighthouse
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12.13.1
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines --prefer-offline
+
+      - name: run OCW import and build
+        run: npm run build:netlify
+        env:
+          DEPLOY_PRIME_URL: "https://deploy-preview-${{ github.event.number }}--ocw-next.netlify.app/"
+          ENV_DEFAULT_REGION: ${{ secrets.ENV_DEFAULT_REGION }}
+          ENV_ACCESS_KEY: ${{ secrets.ENV_ACCESS_KEY }}
+          ENV_SECRET_ACCESS_KEY: ${{ secrets.ENV_SECRET_ACCESS_KEY }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          SEARCH_API_URL: ${{ secrets.SEARCH_API_URL }}
+
+      - name: Deploy PR Preview to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          publish-dir: './dist'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          overwrites-pull-request-comment: true
+          alias: deploy-preview-${{ github.event.number }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Deploy CI build to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        if: ${{ github.event_name == 'push' }}
+        with:
+          publish-dir: './dist'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          alias: ocw-next
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+  lighthouse:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@master
+      - run: mkdir /tmp/artifacts
+
+      - name: Set up node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12.13.1
+
+      - name: Run Lighthouse
+        uses: foo-software/lighthouse-check-action@master
+        id: lighthouseCheck
+        with:
+          branch: ${{ github.ref }}
+          outputDirectory: /tmp/artifacts
+          urls: 'https://deploy-preview-${{ github.event.number }}--ocw-next.netlify.app/,https://deploy-preview-${{ github.event.number }}--ocw-next.netlify.app/search/,https://deploy-preview-${{ github.event.number }}--ocw-next.netlify.app/courses/res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015/'
+          sha: ${{ github.sha }}
+
+      - name: Set comment body
+        id: set-comment-body
+        run: |
+          body=$(echo '${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}' | node build-scripts/formatLighthouseComment.js)
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}" 
+          echo ::set-output name=body::$body
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "Lighthouse results:"
+
+      - name: Create comment
+        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.set-comment-body.outputs.body }}
+
+      - name: Update comment
+        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: ${{ steps.set-comment-body.outputs.body }}

--- a/build-scripts/formatLighthouseComment.js
+++ b/build-scripts/formatLighthouseComment.js
@@ -1,0 +1,83 @@
+const readline = require("readline")
+
+const emojify = score => {
+  if (score === 100) {
+    return "💯"
+  }
+
+  if (score >= 90) {
+    return "🎉"
+  }
+
+  if (score >= 80) {
+    return "😄"
+  }
+
+  if (score >= 70) {
+    return "🙂"
+  }
+
+  if (score >= 60) {
+    return "😐"
+  }
+
+  if (score >= 50) {
+    return "😟"
+  }
+
+  if (score >= 40) {
+    return "😨"
+  }
+
+  if (score >= 30) {
+    return "😰"
+  }
+
+  if (score >= 20) {
+    return "😱"
+  }
+
+  return "😵"
+}
+
+async function main() {
+  const rl = readline.createInterface({
+    input: process.stdin
+  })
+
+  let input = ""
+
+  for await (const line of rl) {
+    input += line
+  }
+
+  const { data } = JSON.parse(input)
+
+  let message = "Lighthouse results:\n"
+
+  message += data
+    .map(entry => {
+      const { url, scores } = entry
+      const {
+        accessibility,
+        bestPractices,
+        performance,
+        progressiveWebApp,
+        seo
+      } = scores
+
+      return `\nresults for <${url}>:
+
+| Accessibility   | Best Practices  | Performance  | Progressive Web App | SEO    |
+| --------------- | --------------- | ------------ | ------------------- | ------ |
+|${accessibility} ${emojify(accessibility)} |${bestPractices} ${emojify(
+  bestPractices
+)} |${performance} ${emojify(performance)}|${progressiveWebApp} ${emojify(
+  progressiveWebApp
+)} | ${seo} ${emojify(seo)} |\n\n`
+    })
+    .join("")
+  console.log(message)
+}
+
+main()


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #367 

#### What's this PR do?

this reconfigures our netlify PR and CI builds to be done through github actions, instead of netlify's automatic integration, and then on PRs runs google pagespeed on the completed build.

I have it set up right now to write a simple comment on the PR with the results of the pagespeed run. The code written here for the action could also be repackaged as our own custom action if we want to add this to other repositories.

#### How should this be manually tested?

Review the .yml stuff carefully for any errors in logic and so on. The github actions documentation [here](https://docs.github.com/en/free-pro-team@latest/actions/reference) may be helpful for doing so.

I wrote logic here to deploy the CI build (<https://ocw-next.netlify.app/>) but I don't have a way to test it without merging to master, so we'll have to just carefully review it and then see how it goes when it merges. I think it should be good because it's the same as the config for deploying the PR builds, just with a different `alias` (the bit it puts as the subdomain before `.netlify.app`)
