### PR TITLE
Nowrap and underline topic links

### DIFF
--- a/src/css/search.scss
+++ b/src/css/search.scss
@@ -142,6 +142,3 @@ form.search-box {
     text-decoration: underline !important;
   }
 }
-
-
-

--- a/src/css/search.scss
+++ b/src/css/search.scss
@@ -134,3 +134,14 @@ form.search-box {
     font-size: 36px;
   }
 }
+
+.listitem {
+  .topic-link {
+    float: left;
+    white-space: nowrap;
+    text-decoration: underline !important;
+  }
+}
+
+
+

--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -140,7 +140,7 @@ export function LearningResourceDisplay(props) {
                     }
                   })}`}
                 >
-                  {topic.name}
+                  {topic.name}{idx < (object.topics.length - 1) ? "," : ""}
                 </a>
               ))}
             </Subtitle>

--- a/src/js/components/SearchResult.js
+++ b/src/js/components/SearchResult.js
@@ -140,7 +140,8 @@ export function LearningResourceDisplay(props) {
                     }
                   })}`}
                 >
-                  {topic.name}{idx < (object.topics.length - 1) ? "," : ""}
+                  {topic.name}
+                  {idx < object.topics.length - 1 ? "," : ""}
                 </a>
               ))}
             </Subtitle>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review

#### What are the relevant tickets?
Partially addresses #409 

#### What's this PR do?
Prevents a multi-word topic from being split into multiple lines, adds commas, and underlines the links.

#### How should this be manually tested?
Go to the search page, try it out in desktop and mobile view.

#### Screenshots (if appropriate)
##### Mobile
<img width="345" alt="Screen Shot 2020-12-07 at 12 13 21 PM" src="https://user-images.githubusercontent.com/187676/101389401-60c60100-388f-11eb-8295-fc7007aab5b1.png">

##### Desktop
<img width="791" alt="Screen Shot 2020-12-07 at 12 12 58 PM" src="https://user-images.githubusercontent.com/187676/101389402-615e9780-388f-11eb-9de4-e91a6d5f25eb.png">

